### PR TITLE
Proofread all docs: fix typos, grammar, and formatting

### DIFF
--- a/docs/architecture/codebase-structure.md
+++ b/docs/architecture/codebase-structure.md
@@ -29,7 +29,7 @@ src/
 ├── crypto/              # Cryptographic primitives
 ├── index/               # Block and tx indexes
 ├── interfaces/          # Interface definitions
-├── kernel/              # Libbitcoinkernel
+├── kernel/              # libbitcoinkernel
 ├── net/                 # Networking code
 ├── node/                # Node-specific code
 ├── policy/              # Mempool policy

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -14,7 +14,7 @@ Bitcoin Knots is an enhanced derivative of [Bitcoin Core](https://bitcoincore.or
 
 Bitcoin Knots was originally known as "Bitcoin LJR" when it emerged in 2011. Luke Dashjr, one of the earliest and most active contributors to Bitcoin Core (involved since 2010), created Knots to include modifications and improvements that hadn't been merged into Core.
 
-The name "Knots" has dual meaning — it references both the merging/tying together of code branches, and pays homage to a biblical passage significant to Dashjr's Roman Catholic faith.
+The name "Knots" has a dual meaning — it both references the merging/tying together of code branches and pays homage to a biblical passage significant to Dashjr's Roman Catholic faith.
 
 **Key milestones:**
 - **2011**: Project launched as Bitcoin LJR

--- a/docs/guides/bip-110.md
+++ b/docs/guides/bip-110.md
@@ -91,7 +91,7 @@ Released January 3, 2026:
 - Fixed spurious Taproot deployment warning
 - Proper preferred peer requests when querying DNS seeds
 
-**Known issue**: Peer-finding difficulties when upgrading from non-BIP110 clients (workaround: delete `peers.dat` or use `addnode=`)
+**Known issue**: Peer-finding difficulties when upgrading from non-BIP-110 clients (workaround: delete `peers.dat` or use `addnode=`)
 
 ## Arguments For BIP-110
 

--- a/docs/guides/creating-a-fork.md
+++ b/docs/guides/creating-a-fork.md
@@ -274,7 +274,7 @@ argsman.AddArg("-datacarriersize",
 
 Create a file documenting what you changed:
 
-```bash
+````bash
 cat > doc/my-policy-changes.md << 'EOF'
 # My Policy Fork Changes
 
@@ -330,7 +330,7 @@ To update this fork when Core releases a new version:
 4. Rebuild and test
 
 EOF
-```
+````
 
 ## Step 6: Commit Your Changes
 

--- a/docs/guides/op-return-controversy.md
+++ b/docs/guides/op-return-controversy.md
@@ -34,7 +34,7 @@ The limit was a deliberate policy choice: Bitcoin is for peer-to-peer electronic
 
 ## Historical Context: The 2014 OP_RETURN Wars
 
-The 2025 controversy isn't new — OP_RETURN limits have been contentious since introduction.
+The 2025 controversy isn't new — OP_RETURN limits have been contentious since their introduction.
 
 ### The Original Compromise (2014)
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -338,7 +338,7 @@ rpcallowip=10.0.0.5/32
 **For remote access, use SSH tunnel instead:**
 ```bash
 ssh -L 8332:localhost:8332 user@node-server
-bitcoin-cli -rpcconnect=127.0.0.1 getinfo
+bitcoin-cli -rpcconnect=127.0.0.1 -getinfo
 ```
 
 ## Wallet Issues
@@ -394,7 +394,7 @@ bitcoin-cli testmempoolaccept '["0200000001..."]'
 | "min relay fee not met" | Fee too low | Bump fee or wait |
 | "insufficient fee" | Below mempool minimum | Increase fee rate |
 | "non-final" | Timelock not reached | Wait for block height/time |
-| "mempool full" | Low-fee during congestion | Increase fee |
+| "mempool full" | Low fee during congestion | Increase fee |
 | "txn-mempool-conflict" | Double spend in mempool | One version already there |
 
 **Knots filtering considerations:**

--- a/docs/patches/networking/tor-integration.md
+++ b/docs/patches/networking/tor-integration.md
@@ -153,7 +153,7 @@ onlynet=onion
 :::warning Tor-Only Tradeoffs
 - Slower initial sync (Tor bandwidth limited)
 - Fewer available peers
-- Potential for Sybil attacks if attacker controls many onion nodes
+- Potential for Sybil attacks if an attacker controls many onion nodes
 - Consider starting with clearnet sync, then switching to Tor-only
 :::
 

--- a/docs/patches/rpc/enhanced-commands.md
+++ b/docs/patches/rpc/enhanced-commands.md
@@ -78,7 +78,7 @@ Additional fields:
 - `misbehaving_score`: Peer misbehavior score
 - `last_block_announcement`: Time of last block announcement
 
-## fundraw
+## fundrawtransaction
 
 Enhanced with `min_conf` option:
 

--- a/docs/patches/wallet/legacy-wallet.md
+++ b/docs/patches/wallet/legacy-wallet.md
@@ -104,7 +104,7 @@ bitcoin-cli -rpcwallet=mylegacy migratewallet
 :::warning Migration Notes
 - Creates a new descriptor wallet
 - Old wallet becomes read-only backup
-- Watchonly items go to separate watchonly wallet
+- Watchonly items go to a separate watchonly wallet
 - **Make a backup before migrating**
 :::
 

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -22,7 +22,7 @@ Luke Dashjr (luke-jr), one of the earliest Bitcoin developers (involved since 20
 
 ### Why is it called "Knots"?
 
-The name has dual meaning:
+The name has a dual meaning:
 - **Technical**: References the merging/tying together of code branches and patches
 - **Personal**: A reference to a biblical passage significant to Dashjr's faith
 


### PR DESCRIPTION
## Summary

Full proofreading pass over all 41 docs files (~9,000 lines), done with 7 parallel review agents. Only objective fixes applied; factual concerns flagged separately (see follow-up issue).

### Fixes
- **creating-a-fork.md** — broken nested code fence: a ```ini fence inside a bash heredoc closed the outer block early, rendering the rest of the heredoc as page content. Outer fence now uses four backticks.
- **enhanced-commands.md** — wrong RPC heading `fundraw` → `fundrawtransaction`
- **troubleshooting.md** — `bitcoin-cli ... getinfo` → `-getinfo` (bare `getinfo` RPC no longer exists); stray hyphen in error table
- **introduction.mdx / faq.md** — "has dual meaning" → "has a dual meaning"; parallelism fix
- **op-return-controversy.md** — "since introduction" → "since their introduction"
- **tor-integration.md / legacy-wallet.md** — missing articles
- **bip-110.md** — "non-BIP110" → "non-BIP-110" for consistent hyphenation
- **codebase-structure.md** — "Libbitcoinkernel" → "libbitcoinkernel"

All internal links, tables, and code fences across the site were verified.

Closes #3