### PR TITLE
Fix factual errors across docs, verified against Knots source

### DIFF
--- a/docs/architecture/build-system.md
+++ b/docs/architecture/build-system.md
@@ -6,7 +6,7 @@ description: Building Bitcoin Knots from source
 
 # Build System
 
-Bitcoin Knots uses the same build system as Bitcoin Core, supporting both CMake and Autotools.
+Bitcoin Knots uses the same build system as Bitcoin Core: CMake. The build system was migrated from Autotools to CMake in v29, so there is no `./autogen.sh` or `./configure` in current branches.
 
 ## Quick Build (Linux)
 
@@ -17,52 +17,32 @@ cd bitcoin
 git checkout 29.x-knots
 
 # Install dependencies (Debian/Ubuntu)
-sudo apt-get install build-essential libtool autotools-dev automake \
-  pkg-config bsdmainutils python3 libssl-dev libevent-dev \
-  libboost-dev libsqlite3-dev
+sudo apt-get install build-essential cmake pkgconf python3 \
+  libevent-dev libboost-dev libsqlite3-dev
 
 # For Qt GUI, also install:
 sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev \
   qttools5-dev-tools libqrencode-dev
 
 # Build
-./autogen.sh
-./configure
-make -j$(nproc)
-```
-
-## CMake Build (Preferred for v28+)
-
-```bash
-mkdir build && cd build
-cmake ..
-make -j$(nproc)
+cmake -B build
+cmake --build build -j$(nproc)
 ```
 
 ## Build Options
 
-### Configure Options
-
 ```bash
-# Disable wallet
-./configure --disable-wallet
+# List all options
+cmake -B build -LH
 
-# Disable GUI
-./configure --without-gui
+# Disable wallet
+cmake -B build -DENABLE_WALLET=OFF
+
+# Build the GUI
+cmake -B build -DBUILD_GUI=ON
 
 # Enable debug
-./configure --enable-debug
-
-# Static linking
-./configure --enable-static
-```
-
-### CMake Options
-
-```bash
-cmake -DBUILD_WALLET=OFF ..
-cmake -DBUILD_GUI=OFF ..
-cmake -DCMAKE_BUILD_TYPE=Debug ..
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
 ```
 
 ## Dependencies
@@ -73,7 +53,6 @@ cmake -DCMAKE_BUILD_TYPE=Debug ..
 |------------|---------|
 | Boost | General utilities |
 | libevent | Network events |
-| OpenSSL/LibreSSL | Cryptography |
 
 ### Optional
 
@@ -94,10 +73,10 @@ Using the depends system:
 cd depends
 make HOST=x86_64-w64-mingw32 -j$(nproc)
 
-# Configure with depends
+# Configure with the depends toolchain
 cd ..
-./configure --prefix=$PWD/depends/x86_64-w64-mingw32
-make -j$(nproc)
+cmake -B build --toolchain depends/x86_64-w64-mingw32/toolchain.cmake
+cmake --build build -j$(nproc)
 ```
 
 ## Reproducible Builds (Guix)
@@ -112,13 +91,13 @@ Produces deterministic binaries that can be verified by multiple builders.
 
 ```bash
 # Unit tests
-make check
+ctest --test-dir build
 
 # Functional tests
-./test/functional/test_runner.py
+build/test/functional/test_runner.py
 
 # Specific test
-./test/functional/test_runner.py wallet_basic.py
+build/test/functional/test_runner.py wallet_basic.py
 ```
 
 ## See Also

--- a/docs/architecture/code-analysis.md
+++ b/docs/architecture/code-analysis.md
@@ -78,7 +78,7 @@ This is the code that warrants the most scrutiny. Let's examine it in detail.
 
 | Category | Files | Insertions | Deletions | Notes |
 |----------|-------|------------|-----------|-----|
-| **validation.cpp** | 1 | ~500 | ~150 | Policy hooks, performance |
+| **validation.cpp** | 1 | ~550 | ~200 | Policy hooks, performance |
 | **script/** | 16 | ~500 | ~100 | Descriptors, signing |
 | **consensus/** | 3 | ~150 | ~50 | Mostly comments/structure |
 | **bitcoinconsensus** | 2 | 252 | 0 | Restored Core code |

--- a/docs/architecture/code-review.md
+++ b/docs/architecture/code-review.md
@@ -19,8 +19,8 @@ This review was conducted using AI-assisted static code analysis. It is not a fo
 
 | Category | Files Changed | Lines Added | Consensus Changes Found |
 |----------|---------------|-------------|------------------------|
-| `script/interpreter.cpp` | 1 | +90 | **None** |
-| `validation.cpp` | 1 | +591 | **None** |
+| `script/interpreter.cpp` | 1 | +68 | **None** |
+| `validation.cpp` | 1 | +551 | **None** |
 | `consensus/` | 3 | +94 | **None** |
 | `script/bitcoinconsensus.*` | 2 | +252 | **None** (restored Core code) |
 
@@ -72,7 +72,7 @@ For each change, we asked:
 
 ### 1. script/interpreter.cpp
 
-**Lines changed:** +90 insertions, -28 deletions
+**Lines changed:** +68 insertions, -22 deletions
 
 #### Finding 1.1: SigHashCache Performance Optimization
 
@@ -132,7 +132,7 @@ git diff FETCH_HEAD..HEAD -- src/script/interpreter.cpp | grep -E "EvalScript|Ve
 
 ### 2. validation.cpp
 
-**Lines changed:** +591 insertions, -210 deletions
+**Lines changed:** +551 insertions, -199 deletions
 
 This is the largest diff, but examination reveals all changes are **policy options**.
 

--- a/docs/architecture/consensus-adjacent-code.md
+++ b/docs/architecture/consensus-adjacent-code.md
@@ -108,7 +108,7 @@ The `script/` directory contains Bitcoin's Script interpreter. Changes here coul
 | `descriptor.cpp` | Enhanced | More descriptor types |
 | `sign.cpp` | Enhanced | BIP-322 message signing |
 | `signingprovider.cpp` | Enhanced | Codex32 seed support |
-| `interpreter.cpp` | Minimal | Comments only |
+| `interpreter.cpp` | +68/−22 | Sighash caching + optional policy check |
 
 ### Descriptor Enhancements
 
@@ -130,18 +130,18 @@ BIP-322 provides a standard way to sign messages with Bitcoin keys. It's used fo
 
 ### What's NOT Changed
 
-The core Script interpreter (`interpreter.cpp`) has minimal changes:
+The core Script interpreter (`interpreter.cpp`) has modest changes (+68/−22): a `SigHashCache` performance optimization that caches signature hash midstates, and an optional policy-only SIGHASH_ALL check. See the [code review](/architecture/code-review) for the full analysis.
 
 ```bash
 # Check interpreter changes
-git diff FETCH_HEAD..HEAD -- src/script/interpreter.cpp | wc -l
-# Result: Very few lines, mostly comments
+git diff FETCH_HEAD..HEAD -- src/script/interpreter.cpp
 ```
 
 Critical functions remain untouched:
 - `EvalScript()` — Script execution
 - `VerifyScript()` — Script verification
 - Opcode implementations
+- `SignatureHashSchnorr()` — Taproot sighash
 
 ## 3. consensus/ Directory Changes
 
@@ -309,7 +309,7 @@ If you want to commission a professional audit of Knots' consensus-adjacent code
 
 1. The scope is manageable (~1,400 lines)
 2. Focus on `validation.cpp` policy hooks
-3. Verify `interpreter.cpp` is unchanged
+3. Review the `interpreter.cpp` changes (sighash caching and the optional SIGHASH_ALL policy check)
 4. Confirm consensus parameters match Core
 
 ## Verify Everything

--- a/docs/getting-started/differences-from-core.md
+++ b/docs/getting-started/differences-from-core.md
@@ -26,9 +26,9 @@ The differences are in:
 
 | Feature | Bitcoin Core | Bitcoin Knots |
 |---------|--------------|---------------|
-| `datacarriersize` | Fixed 80 bytes | Configurable (default 83) |
+| `datacarriersize` | Configurable (default 83 through v29; 100,000 in v30) | Configurable (default 83, hard-capped at 83) |
 | `datacarriercost` | N/A | Configurable weight multiplier |
-| `rejecttokens` | N/A | Filter BRC-20/token transactions |
+| `rejecttokens` | N/A | Filter Runes/Stamps token transactions |
 | `rejectparasites` | N/A | Filter CAT21 spam transactions |
 | `bytespersigopstrict` | N/A | Stricter sigops enforcement |
 | `dustdynamic` | N/A | Dynamic dust threshold |
@@ -63,9 +63,9 @@ bitcoin-cli dumpprivkey <address>
 
 | Command | Description |
 |---------|-------------|
-| `sweepprivkeys` | Import and sweep private keys |
+| `sweepprivkeys` | Sweep private keys into the wallet |
 | `dumpmasterprivkey` | Export HD master private key |
-| `signmessagewithprivkey` | BIP-322 enhanced signing |
+| `signmessage` / `verifymessage` | BIP-322 signature support |
 
 ### Codex32 Support
 
@@ -77,10 +77,10 @@ Knots includes Codex32 seed phrase import for hardware wallet recovery.
 
 ```bash
 # List mempool transactions (Knots)
-bitcoin-cli listmempooltxs
+bitcoin-cli listmempooltransactions
 
 # Get block file locations
-bitcoin-cli getblocklocations <blockhash>
+bitcoin-cli getblocklocations <blockhash> 1
 
 # Fee histogram data
 bitcoin-cli getmempoolinfo

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -50,7 +50,7 @@ First, import Luke Dashjr's GPG key:
 # Import Luke's key from a keyserver
 gpg --keyserver hkps://keys.openpgp.org --recv-keys 0xE463A93F5F3117EEDE6C7316BD02942421F4889F
 
-# Or from the SKS keyserver pool
+# Or from Ubuntu's keyserver (run by Canonical)
 gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 0xE463A93F5F3117EEDE6C7316BD02942421F4889F
 ```
 
@@ -183,7 +183,7 @@ mv bitcoin-29.2.knots20251110 /Applications/Bitcoin-Knots
 ### First Run
 
 macOS will require you to approve the application:
-1. Open System Preferences → Security & Privacy
+1. Open System Settings → Privacy & Security
 2. Click "Open Anyway" for Bitcoin Knots binaries
 
 ## Windows Installation
@@ -203,14 +203,13 @@ cd bitcoin
 git checkout v29.2.knots20251110
 
 # Install dependencies (Debian/Ubuntu)
-sudo apt-get install build-essential cmake pkg-config bsdmainutils \
-  python3 libssl-dev libevent-dev libboost-dev libsqlite3-dev
+sudo apt-get install build-essential cmake pkgconf python3 \
+  libevent-dev libboost-dev libsqlite3-dev
 
 # Build with CMake (v29+)
-mkdir build && cd build
-cmake ..
-make -j$(nproc)
-sudo make install
+cmake -B build
+cmake --build build -j$(nproc)
+sudo cmake --install build
 ```
 
 :::tip Build System Change

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -14,7 +14,7 @@ Bitcoin Knots is an enhanced derivative of [Bitcoin Core](https://bitcoincore.or
 
 Bitcoin Knots was originally known as "Bitcoin LJR" when it emerged in 2011. Luke Dashjr, one of the earliest and most active contributors to Bitcoin Core (involved since 2010), created Knots to include modifications and improvements that hadn't been merged into Core.
 
-The name "Knots" has a dual meaning — it both references the merging/tying together of code branches and pays homage to a biblical passage significant to Dashjr's Roman Catholic faith.
+The name "Knots" has a dual meaning — it both references the merging/tying together of code branches and is reportedly a nod to the "whip of knots" Jesus used to expel the money changers from the Temple (John 2:15), reflecting Dashjr's Roman Catholic faith.
 
 **Key milestones:**
 - **2011**: Project launched as Bitcoin LJR
@@ -23,7 +23,7 @@ The name "Knots" has a dual meaning — it both references the merging/tying tog
 - **2025**: Adoption surged 638% as debates over OP_RETURN limits intensified
 - **November 2025**: Current release v29.2.knots20251110
 
-As of late 2025, Bitcoin Knots powers approximately 21% of all Bitcoin nodes — a significant share of the network's infrastructure.
+As of mid-2026, Bitcoin Knots powers approximately 23% of all Bitcoin nodes — a significant share of the network's infrastructure.
 
 ## What Makes Knots Different?
 

--- a/docs/guides/bip-110.md
+++ b/docs/guides/bip-110.md
@@ -9,11 +9,11 @@ description: Understanding the temporary soft fork proposal to restrict arbitrar
 BIP-110 (originally called BIP-444) is a **temporary soft fork proposal** that would restrict arbitrary data storage on Bitcoin for approximately one year. It represents the most aggressive technical response to the OP_RETURN controversy.
 
 :::info Current Status
-- **Official designation**: BIP-110 (assigned December 2025)
+- **Official designation**: BIP-110, "Reduced Data Temporary Softfork" (number in community use from December 2025; merged into the BIP repository February 7, 2026)
 - **Author**: Dathon Ohm (pseudonymous)
-- **Activation client**: RC2 released January 3, 2026
-- **Signaling**: Begins December 1, 2025
-- **Threshold**: 55% miner support required
+- **Activation client**: v0.4.1 released March 10, 2026 (based on Knots v29.3)
+- **Signaling**: Began ~December 1, 2025 (bit 4)
+- **Threshold**: 55% miner signaling for *early* lock-in; mandatory signaling guarantees activation by block 965,664 regardless
 :::
 
 ## Background
@@ -38,23 +38,26 @@ The proposal was initially called "BIP-444" and contained controversial language
 
 ### Key Features
 
-- **Temporary**: Auto-expires after ~1 year (block height 987,424)
+- **Temporary**: Auto-expires 52,416 blocks (~1 year) after activation — at the latest block 1,018,080 (~September 2027) if activation occurs at the maximum height
 - **Grandfathered UTXOs**: Pre-existing outputs exempt from restrictions
-- **UASF mechanism**: User-activated, not miner-activated
-- **Knots-based**: Built on Bitcoin Knots, not Core
+- **Guaranteed activation for client nodes**: BIP8(LOT=true)-style — 55% miner signaling triggers early lock-in, but mandatory signaling before block 963,648 means activation cannot fail for nodes running the client; there is no timeout
+- **Knots-based**: The activation client is built on Bitcoin Knots, not Core
 
 ## Activation Timeline
 
 ```
 Dec 1, 2025    Signaling begins (bit 4)
                ↓
-               55% threshold (1,109/2,016 blocks)
+               Early lock-in possible at 55% (1,109/2,016 blocks)
+               ↓
+               Mandatory signaling window (blocks 961,632-963,647):
+               non-signaling blocks rejected, guaranteeing lock-in
                ↓
 ~Sept 1, 2026  Max activation (block 965,664)
                ↓
-               ~52,416 blocks (~1 year)
+               Active for 52,416 blocks (~1 year)
                ↓
-               Auto-expiry (unless extended)
+~Sept 2027     Auto-expiry (at the latest, block 1,018,080)
 ```
 
 ## The Activation Client
@@ -65,6 +68,10 @@ Dec 1, 2025    Signaling begins (bit 4)
 |---------|------|--------|
 | **RC1** | December 10, 2025 | Buggy — severe criticism |
 | **RC2** | January 3, 2026 | Fixes applied |
+| **RC3** | January 19, 2026 | Further fixes |
+| **v0.1** | January 28, 2026 | First final release |
+| **v0.2 / v0.3** | February 13-15, 2026 | Incremental updates |
+| **v0.4.1** | March 10, 2026 | Rebased on Knots v29.3 |
 
 ### RC1 Problems
 
@@ -150,32 +157,32 @@ Some observers compare BIP-110's rushed development to the failed SegWit2x fork 
 
 ## Current Miner Signaling
 
-As of January 2026, miner signaling for BIP-110 is minimal. The 55% threshold has not been approached.
+Miner signaling was minimal through early 2026; the first block signaling for BIP-110 was mined in March 2026. The 55% early lock-in threshold has not been approached.
 
-Key mining pools have not publicly committed to supporting or opposing the proposal.
+Most major mining pools have not publicly committed to supporting or opposing the proposal.
 
 ## Relationship to Bitcoin Knots
 
-BIP-110 is built on **Bitcoin Knots**, not Bitcoin Core. This is significant because:
+The BIP-110 activation client is a **standalone fork based on Bitcoin Knots**, published separately by the BIP author. It is **not part of official Bitcoin Knots releases** — the pull request to merge it into Knots ([bitcoinknots/bitcoin#238](https://github.com/bitcoinknots/bitcoin/pull/238)) was closed unmerged. The Knots connection is significant because:
 
 - Knots already has conservative defaults (83-byte OP_RETURN limit)
 - Knots users are the natural constituency for BIP-110
-- The ~21% of nodes running Knots represents the potential base
+- The ~23% of nodes running Knots represents the potential base
 
 However, even many Knots supporters are skeptical of consensus-level restrictions, preferring policy-level solutions.
 
 ## What Happens If It Activates?
 
-**If BIP-110 activates** (55% miner support reached):
+**For nodes running the activation client**, activation is guaranteed (mandatory signaling, no timeout). Once active:
 - Transactions violating the seven rules become invalid
 - Ordinals-style inscriptions would be blocked
 - Large OP_RETURN outputs would be rejected
 - Restrictions last ~1 year, then expire
 
-**If it fails to activate**:
-- No consensus change occurs
+**The real question is economic adoption.** If only a small minority of the economy runs the client:
+- The new rules don't bind the wider network
+- Client nodes risk splitting onto a minority chain (see Chain Split Risk above)
 - The debate continues at the policy level
-- Proponents may attempt a revised proposal
 
 ## How to Monitor
 
@@ -191,6 +198,7 @@ However, even many Knots supporters are skeptical of consensus-level restriction
 
 ## Sources
 
+- [BIP-110 Specification](https://github.com/bitcoin/bips/blob/master/bip-0110.mediawiki) — Official BIP text
 - [BIP-110 Official Site](https://bip110.org/)
 - [BIP-110 GitHub Repository](https://github.com/dathonohm/bitcoin)
 - [BIP-110 RC2 Release Notes](https://github.com/dathonohm/bitcoin/releases/tag/v29.2.knots20251110%2Bbip110-v0.1rc2)

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -97,12 +97,12 @@ datacarriercost=1.0
 # Reject token transactions
 rejecttokens=1
 
-# Reject inscription transactions
+# Reject CAT21 spam transactions
 rejectparasites=1
 
 # Bytes per sigop
 bytespersigop=20
-bytespersigopstrict=1
+bytespersigopstrict=20
 
 # Dust settings
 dustdynamic=1

--- a/docs/guides/creating-a-fork.md
+++ b/docs/guides/creating-a-fork.md
@@ -79,7 +79,7 @@ Most successful implementations started as personal projects. Build something yo
 
 ### The Scenario
 
-Bitcoin Core v30 removed the standardness limit on OP_RETURN outputs. Previously, the default was 80 bytes. Now there's effectively no limit enforced at the policy level.
+Bitcoin Core v30 effectively removed the standardness limit on OP_RETURN outputs. Previously, the default `datacarriersize` was 83 bytes (80 bytes of data plus script overhead). In v30 the default jumped to 100,000 bytes, so there's effectively no limit enforced at the policy level.
 
 You might:
 - Disagree with this change
@@ -129,7 +129,7 @@ You'll need:
 **Ubuntu/Debian:**
 ```bash
 sudo apt-get update
-sudo apt-get install -y build-essential libtool autotools-dev automake pkg-config bsdmainutils python3
+sudo apt-get install -y build-essential cmake pkgconf python3
 sudo apt-get install -y libevent-dev libboost-dev libsqlite3-dev
 sudo apt-get install -y libminiupnpc-dev libnatpmp-dev libzmq3-dev
 # For GUI (optional)
@@ -353,39 +353,34 @@ Rationale: [Your reason]"
 
 ## Step 7: Build Your Fork
 
-### Generate Build System
-
-```bash
-# Run autogen (creates configure script)
-./autogen.sh
-```
-
 ### Configure
 
+Bitcoin Core uses CMake (since v29; there is no `./configure` in a v30 checkout):
+
 ```bash
-# Basic build (no GUI)
-./configure --disable-gui --disable-tests --disable-bench
+# Basic build (no GUI, no tests or benchmarks)
+cmake -B build -DBUILD_TESTS=OFF -DBUILD_BENCH=OFF
 
 # With GUI
-./configure --with-gui=qt5
+cmake -B build -DBUILD_GUI=ON
 
 # See all options
-./configure --help
+cmake -B build -LH
 ```
 
 **Recommended for first build:**
 ```bash
-./configure --disable-tests --disable-bench --with-gui=no
+cmake -B build -DBUILD_TESTS=OFF -DBUILD_BENCH=OFF
 ```
 
 ### Compile
 
 ```bash
 # Use all CPU cores
-make -j$(nproc)
+cmake --build build -j$(nproc)
 
 # Or specify core count
-make -j4
+cmake --build build -j4
 ```
 
 This takes 30-90 minutes depending on your hardware.
@@ -394,13 +389,13 @@ This takes 30-90 minutes depending on your hardware.
 
 ```bash
 # Check the binary exists
-ls -la src/bitcoind src/bitcoin-cli
+ls -la build/bin/bitcoind build/bin/bitcoin-cli
 
 # Check version
-./src/bitcoind --version
+./build/bin/bitcoind --version
 
 # Verify your change is present
-./src/bitcoind -help | grep datacarriersize
+./build/bin/bitcoind -help | grep datacarriersize
 ```
 
 ## Step 8: Test Your Fork
@@ -447,15 +442,15 @@ rm -rf /tmp/bitcoin-test
 ### Run Automated Tests (Optional but Recommended)
 
 ```bash
-# Rebuild with tests enabled
-./configure --enable-tests
-make -j$(nproc)
+# Rebuild with tests enabled (tests are on by default)
+cmake -B build
+cmake --build build -j$(nproc)
 
 # Run unit tests
-make check
+ctest --test-dir build
 
 # Run specific policy tests
-./test/functional/mempool_datacarrier.py
+build/test/functional/mempool_datacarrier.py
 ```
 
 ## Step 9: Install Your Fork
@@ -463,7 +458,7 @@ make check
 ### Option A: Install System-Wide
 
 ```bash
-sudo make install
+sudo cmake --install build
 ```
 
 This installs to `/usr/local/bin/`. Your system's `bitcoind` is now your fork.
@@ -472,20 +467,20 @@ This installs to `/usr/local/bin/`. Your system's `bitcoind` is now your fork.
 
 ```bash
 # Add to your PATH
-export PATH="$HOME/bitcoin-dev/bitcoin/src:$PATH"
+export PATH="$HOME/bitcoin-dev/bitcoin/build/bin:$PATH"
 
 # Or create aliases
-alias bitcoind-custom="$HOME/bitcoin-dev/bitcoin/src/bitcoind"
-alias bitcoin-cli-custom="$HOME/bitcoin-dev/bitcoin/src/bitcoin-cli"
+alias bitcoind-custom="$HOME/bitcoin-dev/bitcoin/build/bin/bitcoind"
+alias bitcoin-cli-custom="$HOME/bitcoin-dev/bitcoin/build/bin/bitcoin-cli"
 ```
 
 ### Option C: Parallel Installation
 
 ```bash
 # Install with a different prefix
-./configure --prefix=$HOME/bitcoin-custom
-make -j$(nproc)
-make install
+cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/bitcoin-custom
+cmake --build build -j$(nproc)
+cmake --install build
 
 # Run with explicit path
 ~/bitcoin-custom/bin/bitcoind
@@ -518,10 +513,9 @@ git merge v30.1
 # The conflict will likely be straightforward - just keep your value
 
 # Rebuild
-make clean
-./autogen.sh
-./configure [your options]
-make -j$(nproc)
+rm -rf build
+cmake -B build [your options]
+cmake --build build -j$(nproc)
 ```
 
 ### Tracking Changes
@@ -548,11 +542,11 @@ EOF
 
 If you want to make additional changes, follow the same pattern:
 
-### Example: Also Restore Dust Limit
+### Example: Raise the Dust Limit
 
 ```cpp title="src/policy/policy.h"
-// Restore stricter dust limit
-static constexpr CAmount DUST_RELAY_TX_FEE = 3000; // sat/kvB
+// Raise dust limit above the default of 3000
+static constexpr CAmount DUST_RELAY_TX_FEE = 10000; // sat/kvB
 ```
 
 ### Example: Disable OP_RETURN by Default
@@ -615,7 +609,7 @@ After going through this process, you might appreciate why Bitcoin Knots exists:
 
 | DIY Fork | Bitcoin Knots |
 |----------|---------------|
-| You maintain it | Community maintained (led by Luke Dashjr, longest-active Core contributor) |
+| You maintain it | Maintained by lead maintainer Luke Dashjr with community contributors |
 | You handle security updates | Tracks Core security fixes |
 | Single policy change | Many useful options |
 | Your testing only | Community tested |

--- a/docs/guides/mining.md
+++ b/docs/guides/mining.md
@@ -220,10 +220,9 @@ maxmempool=1000
 ### Solo Mining (Testnet)
 
 ```ini title="bitcoin.conf"
-# Testnet solo mining
+# Testnet node for solo mining
 testnet=1
 server=1
-gen=1
 ```
 
 ```bash

--- a/docs/guides/op-return-controversy.md
+++ b/docs/guides/op-return-controversy.md
@@ -108,8 +108,7 @@ This growth threatens decentralization by making it more expensive to run a node
 - **Visibility problem**: OP_RETURN data is standardized and directly readable, making it more visible to "lawyers, judges, and jurors" than hidden data
 - **No removal option**: Unlike forum operators, node operators cannot simply remove offending data
 
-> "I am talking about very real laws in very real jurisdictions."
-> — Nick Szabo
+Szabo emphasized that he was talking about real laws in real jurisdictions, not hypothetical risks.
 
 ### 4. The "Gallery vs. Drawer" Problem
 
@@ -237,7 +236,7 @@ This PR successfully **removed the deprecation warnings** from the configuration
 
 ### PR #34214 — Restore 80-Byte Default
 
-[PR #34214](https://github.com/bitcoin/bitcoin/pull/34214) in late 2025 attempted to restore the 80-byte default. It cited Nick Szabo's warnings as "new information" that wasn't available during the original debate.
+[PR #34214](https://github.com/bitcoin/bitcoin/pull/34214), opened in January 2026, attempted to restore the 80-byte default. It cited Nick Szabo's warnings as "new information" that wasn't available during the original debate.
 
 The PR was closed with NACKs from maintainers achow101 and glozow, with arguments that:
 - The debate had been settled

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -50,12 +50,12 @@ bitcoind -printtoconsole
 **Symptom:** "Error reading configuration file"
 
 ```bash
-# Validate config file (Knots feature)
-bitcoin-cli -testconfig
+# bitcoind refuses to start on a malformed config —
+# the startup error message names the bad line
 
 # Common syntax errors:
 # - Missing quotes around paths with spaces
-# - Using = for boolean options (use option=1 not option=true)
+# - Wrong boolean syntax (use option=1, not option=true)
 # - Invalid option names
 ```
 
@@ -245,11 +245,12 @@ ln -s /new/location/bitcoin ~/.bitcoin
 # Or use -datadir=/new/location
 ```
 
-**Option 3: Use assumeutxo (Knots/Core v29+)**
+**Option 3: Use assumeutxo (mainnet support since Core v28)**
 ```bash
-# Fast-sync using a UTXO snapshot
-# Downloads and validates in background
-bitcoind -loadtxoutset=/path/to/snapshot.dat
+# Fast-sync using a UTXO snapshot, loaded via RPC
+# while bitcoind is running; full validation
+# continues in the background
+bitcoin-cli loadtxoutset /path/to/snapshot.dat
 ```
 
 ### Slow Disk I/O
@@ -364,17 +365,12 @@ bitcoin-cli loadwallet "mylegacywallet"
 
 **Recovery steps:**
 
-1. **Try loading with salvage:**
-   ```bash
-   bitcoin-cli loadwallet "walletname" false true  # load_on_startup=false, salvage=true
-   ```
-
-2. **Use wallet tool (legacy wallets):**
+1. **Use the wallet tool's salvage command (legacy wallets, experimental):**
    ```bash
    bitcoin-wallet -wallet=~/.bitcoin/wallets/mylegacy salvage
    ```
 
-3. **Restore from backup:**
+2. **Restore from backup:**
    ```bash
    cp /backup/wallet.dat ~/.bitcoin/wallets/mylegacy/
    bitcoin-cli loadwallet "mylegacy"
@@ -399,11 +395,15 @@ bitcoin-cli testmempoolaccept '["0200000001..."]'
 
 **Knots filtering considerations:**
 ```bash
-# If you're running Knots with filtering, check if that's the issue:
-bitcoin-cli getmempoolinfo | grep -E "rejectparasites|rejecttokens"
+# Filtering options are startup settings, not RPC fields —
+# check what the node was started with:
+ps aux | grep bitcoind
+grep -E "rejectparasites|rejecttokens|corepolicy" ~/.bitcoin/bitcoin.conf
 
-# Test without filtering
-bitcoin-cli -corepolicy=1 testmempoolaccept '["rawtx"]'
+# Check why a specific transaction is rejected
+bitcoin-cli testmempoolaccept '["rawtx"]'
+
+# To test without filtering, restart bitcoind with -corepolicy=1
 ```
 
 ### Stuck Unconfirmed Transaction

--- a/docs/guides/wallet-management.md
+++ b/docs/guides/wallet-management.md
@@ -89,7 +89,8 @@ bitcoin-cli -rpcwallet=wallet1 send '{
 ### Sweep Private Keys
 
 ```bash
-bitcoin-cli sweepprivkeys '["5K..."]' "bc1q..."
+# Sweeps to a fresh address in the loaded wallet
+bitcoin-cli sweepprivkeys '{"privkeys": ["5K..."]}'
 ```
 
 ### Dump Master Key (Legacy)

--- a/docs/patches/gui/dark-mode.md
+++ b/docs/patches/gui/dark-mode.md
@@ -28,7 +28,7 @@ Bitcoin Knots respects your system's theme settings:
 - Bitcoin Qt will follow automatically
 
 **macOS:**
-- System Preferences → General → Appearance → Dark
+- System Settings → Appearance → Dark
 - Bitcoin Qt will follow automatically
 
 **Windows 10/11:**

--- a/docs/patches/networking/tor-integration.md
+++ b/docs/patches/networking/tor-integration.md
@@ -243,7 +243,7 @@ This encrypts peer connections, preventing ISPs from inspecting Bitcoin protocol
 | `onion` | proxy | Separate proxy for .onion only |
 | `onlynet` | all | Restrict to specific networks |
 | `listenonion` | 1 | Create onion service |
-| `torcontrol` | none | Tor control port for auth |
+| `torcontrol` | 127.0.0.1:9051 | Tor control host and port |
 | `torpassword` | none | Tor control password |
 | `i2psam` | none | I2P SAM proxy address |
 | `i2pacceptincoming` | 1 | Accept inbound I2P |

--- a/docs/patches/overview.md
+++ b/docs/patches/overview.md
@@ -18,11 +18,11 @@ Control what transactions your node relays and accepts into its mempool.
 
 | Patch | Purpose | Config Option |
 |-------|---------|---------------|
-| `rejecttokens` | Filter BRC-20/token transactions | `rejecttokens=1` (off by default) |
+| `rejecttokens` | Filter Runes/Stamps token transactions | `rejecttokens=1` (off by default) |
 | `rejectparasites` | Filter CAT21 spam transactions | `rejectparasites=1` **(on by default)** |
 | `dustdynamic` | Dynamic dust threshold | `dustdynamic=1` |
 | `datacarriercost` | Weight OP_RETURN data | `datacarriercost=<n>` |
-| `bytespersigopstrict` | Stricter sigops limits | `bytespersigopstrict=1` |
+| `bytespersigopstrict` | Stricter sigops limits | `bytespersigopstrict=20` |
 | `unique_spk_mempool` | One tx per scriptPubKey | Enabled by default |
 | `maxscriptsize` | Maximum script size | `maxscriptsize=<n>` |
 
@@ -115,8 +115,8 @@ Features removed from Bitcoin Core but maintained in Knots.
 
 | Feature | Removed in Core | Status in Knots |
 |---------|-----------------|-----------------|
-| Legacy Wallet | v24+ | Maintained |
-| UPnP | v28 | Restored |
+| Legacy Wallet | v30 (creation deprecated since v26) | Maintained |
+| UPnP | v29 (deprecated in v28) | Restored |
 | `-blockmaxsize` | v0.15 | Restored |
 | `libconsensus` | v28 | Restored |
 | Fee filter option | v24 | Restored |
@@ -164,10 +164,10 @@ git show <commit-hash>
 Most patches add **optional** configuration. Features are not forced on users:
 
 ```ini title="bitcoin.conf"
-# Enable inscription filtering (off by default)
-rejectparasites=1
+# Enable token filtering (off by default)
+rejecttokens=1
 
-# Disable if you want Core behavior
+# Disable CAT21 filtering (on by default) if you want Core behavior
 rejectparasites=0
 ```
 

--- a/docs/patches/policy/dust-and-fees.md
+++ b/docs/patches/policy/dust-and-fees.md
@@ -19,8 +19,8 @@ Bitcoin Knots provides enhanced control over dust thresholds and fee-related pol
 Set the fee rate used to calculate dust threshold:
 
 ```ini title="bitcoin.conf"
-# Satoshis per 1000 bytes
-dustrelayfee=3000
+# Fee rate in BTC per kvB (0.00003 = 3000 sat/kvB, the default)
+dustrelayfee=0.00003
 ```
 
 ### Dynamic Dust
@@ -40,8 +40,8 @@ With dynamic dust enabled, the threshold adjusts based on mempool conditions.
 Set the minimum fee rate for transaction relay:
 
 ```ini title="bitcoin.conf"
-# Satoshis per 1000 virtual bytes
-minrelaytxfee=1000
+# Fee rate in BTC per kvB (0.00001 = 1000 sat/kvB, the default)
+minrelaytxfee=0.00001
 ```
 
 ### Incremental Relay Fee
@@ -49,7 +49,8 @@ minrelaytxfee=1000
 Fee increment required for RBF replacements:
 
 ```ini title="bitcoin.conf"
-incrementalrelayfee=1000
+# Fee rate in BTC per kvB
+incrementalrelayfee=0.00001
 ```
 
 ### Confirmation Target Default

--- a/docs/patches/policy/mempool-policies.md
+++ b/docs/patches/policy/mempool-policies.md
@@ -21,19 +21,19 @@ Policy rules are **local to your node**. They don't affect consensus validation.
 
 ## Transaction Filtering
 
-### Reject Tokens (BRC-20, etc.)
+### Reject Tokens (Runes, Stamps)
 
-Filter transactions related to token protocols that use inscriptions:
+Filter transactions related to token protocols (off by default):
 
 ```ini title="bitcoin.conf"
 rejecttokens=1
 ```
 
-This filters transactions that appear to be BRC-20 or similar token transfers.
+This filters Runes transactions (OP_RETURN outputs starting with OP_13) and OLGA/Bitcoin Stamps data encoding. Note that BRC-20 tokens live in witness inscriptions and are not matched by this option — they are constrained by the data carrier limits instead.
 
 ### Reject Parasites (CAT21)
 
-Filter CAT21 spam transactions:
+Filter CAT21 spam transactions (on by default):
 
 ```ini title="bitcoin.conf"
 rejectparasites=1
@@ -58,8 +58,9 @@ datacarriersize=42
 Control the maximum size of OP_RETURN outputs:
 
 ```ini title="bitcoin.conf"
-# Bitcoin Core default: 80 bytes
-# Knots default: 83 bytes (for legacy protocol compatibility)
+# Bitcoin Core default: 83 bytes through v29 (80 bytes of data
+# plus overhead); raised to 100,000 bytes in Core v30
+# Knots default: 83 bytes (historically 42; raised in 29.2)
 # Recommended for filtering: 42 bytes
 
 datacarriersize=42
@@ -89,10 +90,11 @@ This adjusts the dust threshold based on current fee conditions rather than usin
 
 ### Custom Dust Limit
 
-Set a specific dust limit (in satoshis):
+Set the fee rate used to calculate the dust threshold:
 
 ```ini title="bitcoin.conf"
-dustrelayfee=3000
+# Fee rate in BTC per kvB (0.00003 = 3000 sat/kvB, the default)
+dustrelayfee=0.00003
 ```
 
 ## Sigops Policies
@@ -107,10 +109,11 @@ bytespersigop=20
 
 ### Strict Sigops Enforcement
 
-Enable stricter sigops enforcement:
+Set the minimum bytes per sigop in transactions relayed and mined (a Knots-only option; Core has only `bytespersigop`):
 
 ```ini title="bitcoin.conf"
-bytespersigopstrict=1
+# Minimum bytes per sigop (default: 20)
+bytespersigopstrict=20
 ```
 
 ## Script Policies
@@ -138,8 +141,14 @@ permitbarepubkey=0
 Configure Replace-By-Fee behavior:
 
 ```ini title="bitcoin.conf"
-# Options: 0=never, 1=optin, 2=always
+# Boolean: full RBF on (1, Knots default) or off (0)
 mempoolfullrbf=1
+
+# Knots also has a finer-grained option:
+# 0 = disable RBF entirely
+# fee,optin = honour the RBF opt-in signal
+# fee,-optin = always allow replacement, aka full RBF (default)
+mempoolreplacement=fee,-optin
 ```
 
 ### TRUC Transaction Options
@@ -172,7 +181,7 @@ rejectparasites=1
 datacarriersize=42
 
 # Conservative policies
-bytespersigopstrict=1
+bytespersigopstrict=20
 permitbarepubkey=0
 ```
 

--- a/docs/patches/policy/transaction-filtering.mdx
+++ b/docs/patches/policy/transaction-filtering.mdx
@@ -8,7 +8,7 @@ import ThemedImage from '@theme/ThemedImage';
 
 # Transaction Filtering
 
-Bitcoin Knots provides comprehensive tools to filter transactions you consider spam from your mempool. This is one of the most significant differences from Bitcoin Core and a primary reason for Knots' [850% adoption surge](https://blog.bitfinex.com/education/why-is-bitcoin-knots-becoming-so-popular/) in 2024-2025.
+Bitcoin Knots provides comprehensive tools to filter transactions you consider spam from your mempool. This is one of the most significant differences from Bitcoin Core and a primary reason for Knots' [850% adoption surge](https://blog.bitfinex.com/education/why-is-bitcoin-knots-becoming-so-popular/) in 2025.
 
 <ThemedImage
   alt="Transaction Filtering Flow"
@@ -162,13 +162,10 @@ Detects OP_RETURN outputs starting with OP_13 (the Runes identifier). Updated in
 Maximum size of data in OP_RETURN outputs.
 
 ```ini title="bitcoin.conf"
-# Knots default (legacy compatibility)
+# Knots default (80 bytes of data plus script overhead)
 datacarriersize=83
 
-# Traditional limit (80 bytes of data)
-datacarriersize=83
-
-# Stricter (42 bytes - enough for hashes)
+# Stricter (42 bytes - enough for hashes; the historical Knots default)
 datacarriersize=42
 
 # Disable all OP_RETURN relay
@@ -253,7 +250,7 @@ Useful for testing or if you want Knots features but Core relay behavior.
 Used by [Ocean mining pool](https://ocean.xyz/):
 
 ```ini title="bitcoin.conf"
-# Inscriptions and ordinals
+# CAT21 spam
 rejectparasites=1
 
 # Runes and tokens

--- a/docs/patches/rpc/new-commands.md
+++ b/docs/patches/rpc/new-commands.md
@@ -10,12 +10,12 @@ Bitcoin Knots includes several RPC commands not available in Bitcoin Core.
 
 ## Mempool Commands
 
-### listmempooltxs
+### listmempooltransactions
 
-List transactions in the mempool with filtering options:
+List transactions in the mempool, optionally starting from a given mempool sequence number:
 
 ```bash
-bitcoin-cli listmempooltxs
+bitcoin-cli listmempooltransactions
 ```
 
 ### getmempoolinfo (Enhanced)
@@ -30,20 +30,22 @@ bitcoin-cli getmempoolinfo
 
 ### getblocklocations
 
-Get the file locations of a block:
+Get the file locations of one or more blocks (experimental; unavailable on pruned nodes):
 
 ```bash
-bitcoin-cli getblocklocations "blockhash"
+bitcoin-cli getblocklocations "blockhash" 1
 ```
 
-Returns:
+Returns an array, one entry per block:
 ```json
-{
-  "file": 1234,
-  "pos": 567890,
-  "undo_file": 1234,
-  "undo_pos": 123456
-}
+[
+  {
+    "file": 1234,
+    "data": 567890,
+    "undo": 123456,
+    "prev": "blockhash"
+  }
+]
 ```
 
 ### getblockfileinfo
@@ -58,10 +60,10 @@ bitcoin-cli getblockfileinfo 1234
 
 ### sweepprivkeys
 
-Import and sweep private keys:
+Sweep funds from private keys into the currently loaded wallet (a fresh address is reserved automatically; there is no destination parameter):
 
 ```bash
-bitcoin-cli sweepprivkeys '["privkey1"]' "destination"
+bitcoin-cli sweepprivkeys '{"privkeys": ["privkey1"]}'
 ```
 
 ### dumpmasterprivkey

--- a/docs/patches/wallet/codex32.md
+++ b/docs/patches/wallet/codex32.md
@@ -45,7 +45,7 @@ MS12NAMEA320ZYXWVUTSRQPNMLKJHGFEDCAXRPP870HKKQRM
 │││ │    │              Data + Checksum
 │││ │    └── Share index (A-Z, or S for secret)
 │││ └────── Identifier (4 characters)
-││└──────── Threshold (1-9 shares needed)
+││└──────── Threshold (2-9 shares needed, or 0 for no splitting)
 │└───────── Version (always 1 for now)
 └────────── Human readable part (MS = "master seed")
 ```
@@ -82,7 +82,7 @@ Codex32 uses [Shamir's Secret Sharing](https://en.wikipedia.org/wiki/Shamir%27s_
 
 **Key properties:**
 - Split into up to **31 shares**
-- Threshold from **1 to 9** shares required
+- Threshold from **2 to 9** shares required (or **0** for an unsplit, checksummed secret)
 - Below threshold: **zero information** about secret
 - Mathematical guarantee, not just obscurity
 
@@ -91,37 +91,37 @@ Codex32 uses [Shamir's Secret Sharing](https://en.wikipedia.org/wiki/Shamir%27s_
 The 13-character checksum can:
 - **Detect** up to 8 errors anywhere in the string
 - **Correct** up to 4 character substitutions
-- **Handle** up to 15 consecutive erasures (unreadable characters)
+- **Handle** up to 8 erasures (unreadable characters), or up to 13 if they are consecutive
 
 This means small transcription errors when copying by hand can be automatically fixed.
 
 ## Using Codex32 in Bitcoin Knots
 
+Codex32 import is integrated into the `importdescriptors` RPC via its second parameter, `seeds`. Each entry is a list of codex32 strings — either the unsplit secret (the "S" share) on its own, or enough shares to meet the threshold. The recovered seed supplies the master key material for the descriptors being imported.
+
 ### Importing a Codex32 Seed
 
 ```bash
-# Import a single share (if threshold = 1) or the secret directly
-bitcoin-cli importcodex32 "MS10TESTSXXXXXXXXXXXXXXXXXXXXXXXXXX4NZVSHKZ"
+# Import the secret directly (a single string must be the S share)
+bitcoin-cli importdescriptors \
+  '[{"desc": "<descriptor>", "timestamp": "now", "active": true}]' \
+  '[["MS10TESTSXXXXXXXXXXXXXXXXXXXXXXXXXX4NZVSHKZ"]]'
 ```
 
 ### Importing Multiple Shares
 
-For threshold > 1, you need to combine shares:
+For split backups, provide enough shares to meet the threshold and Knots combines them:
 
 ```bash
-# Import with multiple shares
-bitcoin-cli importcodex32 '[
-  "MS12NAMEA320ZYXWVUTSRQPNMLKJHGFEDCAXRPP870HKKQRM",
-  "MS12NAMEB320ZYXWVUTSRQPNMLKJHGFEDCADH7HDLHPMS5X"
-]'
+bitcoin-cli importdescriptors \
+  '[{"desc": "<descriptor>", "timestamp": "now", "active": true}]' \
+  '[[
+    "MS12NAMEA320ZYXWVUTSRQPNMLKJHGFEDCAXRPP870HKKQRM",
+    "MS12NAMEB320ZYXWVUTSRQPNMLKJHGFEDCADH7HDLHPMS5X"
+  ]]'
 ```
 
-### Verifying a Share
-
-```bash
-# Check if a share is valid (checksum verification)
-bitcoin-cli validatecodex32 "MS12NAMEA320ZYXWVUTSRQPNMLKJHGFEDCAXRPP870HKKQRM"
-```
+Invalid shares are rejected with a checksum error, so a failed import also serves as share validation.
 
 ## Creating Codex32 Backups
 
@@ -195,7 +195,7 @@ Never store all shares in one location. The whole point of splitting is geograph
 :::tip Threshold Selection
 - **Threshold 2 of 3**: Good balance of security and convenience
 - **Threshold 3 of 5**: Higher security for large holdings
-- **Threshold 1**: No splitting (just checksummed backup)
+- **Threshold 0**: No splitting (just a checksummed backup)
 :::
 
 **Storage recommendations:**
@@ -255,7 +255,7 @@ Codex32 supports standard BIP-32 seed lengths:
 1. Gather any 2 shares (A+B, A+C, or B+C)
 
 2. Use recovery wheel or:
-   bitcoin-cli importcodex32 '["MS12VAULTA...", "MS12VAULTB..."]'
+   bitcoin-cli importdescriptors '[...]' '[["MS12VAULTA...", "MS12VAULTB..."]]'
 
 3. Wallet is restored with full funds access
 ```
@@ -275,7 +275,7 @@ Codex32 uses polynomial interpolation over a finite field:
 - **Generator polynomial**: Specifically chosen for Bech32 alphabet
 - **Error detection**: Guaranteed for up to 8 errors
 - **Error correction**: Can fix 4 substitutions automatically
-- **Erasure handling**: Up to 15 consecutive unreadable characters
+- **Erasure handling**: Up to 8 unreadable characters (13 if consecutive)
 
 ## Wallet Support Status
 

--- a/docs/patches/wallet/legacy-wallet.md
+++ b/docs/patches/wallet/legacy-wallet.md
@@ -14,8 +14,8 @@ Bitcoin Core v30 completely removed Berkeley DB legacy wallet support, forcing u
 |---------|----------|-------------|
 | Legacy wallet creation | **Removed** | Supported |
 | Berkeley DB wallets | **Removed** | Supported |
-| `dumpprivkey` RPC | Descriptor only | **Both types** |
-| `importprivkey` RPC | Descriptor only | **Both types** |
+| `dumpprivkey` RPC | **Removed** (was legacy-only) | Supported |
+| `importprivkey` RPC | **Removed** (was legacy-only) | Supported |
 | Direct key management | Limited | **Full** |
 
 Many users need legacy wallets for:
@@ -84,13 +84,15 @@ bitcoin-cli -rpcwallet=mylegacy backupwallet "/path/to/backup.dat"
 
 ## HD Wallet Derivation
 
-Legacy wallets use BIP32/44 derivation paths:
+Legacy HD wallets use a fixed BIP32 keypath scheme (not BIP44):
 
 ```
-m/44'/0'/0'/0/0  # First receiving address
-m/44'/0'/0'/0/1  # Second receiving address
-m/44'/0'/0'/1/0  # First change address
+m/0'/0'/0'  # First external (receiving) key
+m/0'/0'/1'  # Second external key
+m/0'/1'/0'  # First internal (change) key
 ```
+
+BIP44/49/84/86 paths are what descriptor wallets use by default.
 
 ## Migration to Descriptor Wallet
 
@@ -131,8 +133,13 @@ bitcoin-cli createwallet "mydesc" false false "" false true
 | Command | Description |
 |---------|-------------|
 | `dumpmasterprivkey` | Export HD master key (legacy) |
-| `sweepprivkeys` | Import and sweep in one step |
-| `importfromcoldcard` | Import Coldcard wallet |
+| `sweepprivkeys` | Sweep keys into the wallet in one step |
+
+The offline `bitcoin-wallet` tool also gains an experimental `importfromcoldcard` command for creating a wallet from a Coldcard export:
+
+```bash
+bitcoin-wallet -wallet=mycoldcard -dumpfile=coldcard-export.txt importfromcoldcard
+```
 
 ## See Also
 

--- a/docs/patches/wallet/sweep-keys.md
+++ b/docs/patches/wallet/sweep-keys.md
@@ -24,35 +24,40 @@ Sweeping is safer because:
 
 ### Basic Sweep
 
+The command takes a single options object. Funds are swept to a freshly reserved address in the currently loaded wallet — there is no destination parameter (it isn't safe to sweep-and-send in a single action):
+
 ```bash
-bitcoin-cli sweepprivkeys '["5KJvsngHeMpm884wtkJNzQGaCErckhHJBGFsvd3VyK5qMZXj3hS"]' "bc1q..."
+bitcoin-cli sweepprivkeys '{"privkeys": ["5KJvsngHeMpm884wtkJNzQGaCErckhHJBGFsvd3VyK5qMZXj3hS"]}'
 ```
 
 ### Multiple Keys
 
 ```bash
-bitcoin-cli sweepprivkeys '["key1", "key2", "key3"]' "bc1qyouraddress..."
+bitcoin-cli sweepprivkeys '{"privkeys": ["key1", "key2", "key3"]}'
 ```
 
-### With Custom Fee Rate
+### With a Label
 
 ```bash
-bitcoin-cli sweepprivkeys '["5KJvs..."]' "bc1q..." 10
+bitcoin-cli sweepprivkeys '{"privkeys": ["5KJvs..."], "label": "paper wallet sweep"}'
 ```
 
 ## Parameters
 
-| Parameter | Type | Required | Description |
+A single `options` object:
+
+| Field | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `privkeys` | array | Yes | Array of WIF-encoded private keys |
-| `destination` | string | Yes | Address to receive swept funds |
-| `fee_rate` | number | No | Fee rate in sat/vB (default: automatic) |
+| `label` | string | No | Label for the receiving address |
+
+Returns the txid of the sweep transaction.
 
 ## How It Works
 
 1. **UTXO Scan**: Scans the UTXO set for outputs spendable by the provided keys
 2. **Transaction Creation**: Creates a transaction spending all found UTXOs
-3. **Broadcast**: Sends funds to the destination address
+3. **Broadcast**: Sends funds to a newly reserved address in your wallet
 4. **Cleanup**: Keys are not persisted in the wallet
 
 ```
@@ -67,10 +72,9 @@ bitcoin-cli sweepprivkeys '["5KJvs..."]' "bc1q..." 10
 ### Paper Wallet Redemption
 
 ```bash
-# Sweep a paper wallet to your HD wallet
+# Sweep a paper wallet into your loaded wallet
 PAPER_KEY="5KJvsngHeMpm884wtkJNzQGaCErckhHJBGFsvd3VyK5qMZXj3hS"
-MY_ADDR=$(bitcoin-cli getnewaddress)
-bitcoin-cli sweepprivkeys "[\"$PAPER_KEY\"]" "$MY_ADDR"
+bitcoin-cli sweepprivkeys "{\"privkeys\": [\"$PAPER_KEY\"]}"
 ```
 
 ### Merchant Payment Acceptance
@@ -78,19 +82,20 @@ bitcoin-cli sweepprivkeys "[\"$PAPER_KEY\"]" "$MY_ADDR"
 Merchants can accept payments via typed or scanned private keys:
 
 ```bash
-# Customer provides private key (e.g., from gift card)
-bitcoin-cli sweepprivkeys '["customer_privkey"]' "merchant_address"
+# Customer provides private key (e.g., from gift card);
+# funds are swept into the merchant's loaded wallet
+bitcoin-cli sweepprivkeys '{"privkeys": ["customer_privkey"], "label": "gift card"}'
 ```
 
 ### Consolidating Old Keys
 
 ```bash
-# Sweep multiple old keys to a single new address
-bitcoin-cli sweepprivkeys '[
+# Sweep multiple old keys in one transaction
+bitcoin-cli sweepprivkeys '{"privkeys": [
   "5KJvsngHeMpm...",
   "5HueCGU8rMjx...",
   "5Kb8kLf9zgW..."
-]' "bc1q_consolidation_address"
+]}'
 ```
 
 ## Comparison with Manual Process
@@ -120,7 +125,7 @@ With `sweepprivkeys`:
 
 ```bash
 # One command, key not persisted
-bitcoin-cli sweepprivkeys '["5KJvs..."]' "bc1q..."
+bitcoin-cli sweepprivkeys '{"privkeys": ["5KJvs..."]}'
 ```
 
 ## Security Considerations
@@ -129,8 +134,8 @@ bitcoin-cli sweepprivkeys '["5KJvs..."]' "bc1q..."
 Once you sweep a key, consider it compromised. Never send new funds to addresses derived from that key.
 :::
 
-:::tip Verify Destination
-Always double-check the destination address before sweeping. There's no undo.
+:::tip Sweep, Then Send
+Funds land in the currently loaded wallet. If you want them elsewhere, sweep first, then send a normal transaction — there's no undo.
 :::
 
 ## Error Handling
@@ -139,7 +144,7 @@ Always double-check the destination address before sweeping. There's no undo.
 |-------|-------|----------|
 | "No UTXOs found" | Key has no funds or already swept | Verify key controls expected address |
 | "Invalid private key" | Wrong format or typo | Use WIF format (starts with 5, K, or L) |
-| "Insufficient fee" | Low fee rate during congestion | Increase fee_rate parameter |
+| "Insufficient fee" | Low fee rate during congestion | Retry when fees subside |
 
 ## Related Commands
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -136,12 +136,14 @@ bitcoin-wallet -wallet=existing info
 bitcoin-wallet -wallet=existing dump
 ```
 
-## Environment Variables
+## Setting the Data Directory
 
-| Variable | Description |
-|----------|-------------|
-| `BITCOIN_DATADIR` | Data directory |
-| `BITCOIN_CLI_ARGS` | Default CLI arguments |
+bitcoind and bitcoin-cli do not read environment variables for configuration; use the `-datadir` option or a config file:
+
+```bash
+bitcoind -datadir=/path/to/datadir
+bitcoin-cli -datadir=/path/to/datadir getblockcount
+```
 
 ## See Also
 

--- a/docs/reference/configuration-options.md
+++ b/docs/reference/configuration-options.md
@@ -156,7 +156,7 @@ These options exist in both Core and Knots.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `-softwareexpiry` | bool | 1 | Enable expiry warnings (4-week warning, alerts at expiry) |
+| `-softwareexpiry` | timestamp | ~2 years after release | Stop working after this POSIX timestamp (0 = never; warnings begin 4 weeks before) |
 
 ---
 

--- a/docs/reference/contributing.md
+++ b/docs/reference/contributing.md
@@ -37,8 +37,10 @@ Help translate the interface (when Transifex access is restored).
 
 ### 1. Fork the Repository
 
+Fork [bitcoinknots/bitcoin](https://github.com/bitcoinknots/bitcoin) on GitHub, then clone your fork:
+
 ```bash
-git clone https://github.com/bitcoinknots/bitcoin.git
+git clone https://github.com/<your-username>/bitcoin.git
 cd bitcoin
 git remote add upstream https://github.com/bitcoinknots/bitcoin.git
 ```
@@ -57,8 +59,8 @@ Follow the coding style of the existing codebase.
 ### 4. Test
 
 ```bash
-make check
-./test/functional/test_runner.py
+ctest --test-dir build
+build/test/functional/test_runner.py
 ```
 
 ### 5. Commit

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -24,13 +24,13 @@ Luke Dashjr (luke-jr), one of the earliest Bitcoin developers (involved since 20
 
 The name has a dual meaning:
 - **Technical**: References the merging/tying together of code branches and patches
-- **Personal**: A reference to a biblical passage significant to Dashjr's faith
+- **Personal**: Reportedly a reference to the "whip of knots" Jesus used to expel the money changers from the Temple (John 2:15) — Dashjr is Catholic
 
 The project was originally called "Bitcoin LJR" before being renamed.
 
 ### How popular is Bitcoin Knots?
 
-As of late 2025, Bitcoin Knots powers approximately **21% of all Bitcoin nodes** — a significant portion of the network. Adoption surged 850% in 2024-2025, largely driven by the OP_RETURN controversy and Core v30's removal of data limits.
+As of mid-2026, Bitcoin Knots powers approximately **23% of all Bitcoin nodes** (~5,400 nodes per coin.dance) — a significant portion of the network. Adoption surged 850% during 2025, largely driven by the OP_RETURN controversy and Core v30's removal of data limits.
 
 ---
 
@@ -49,6 +49,7 @@ The ~40,000 lines figure is roughly accurate when counting insertions (~36k). Th
 | RPC | 2,238 | 277 | +1,961 | **Low** - API commands |
 | Policy | 770 | 72 | +698 | **Low** - relay, not consensus |
 | Validation/Script | 1,256 | 306 | +950 | **Review below** |
+| Other (net, init, util, depends, misc) | 5,087 | 129 | +4,958 | **Low** |
 | **Total** | **36,438** | **15,294** | **~21,144** | |
 
 **Key facts:**
@@ -216,13 +217,13 @@ Yes. Both descriptor and legacy wallets are compatible.
 
 ### What is `sweepprivkeys`?
 
-A Knots command to import a private key and immediately send funds to a new address in one atomic operation. Safer than `importprivkey` because:
+A Knots command to sweep funds from a private key into your wallet in one atomic operation. Safer than `importprivkey` because:
 - The imported key isn't stored in your wallet
-- Funds move to an address only you control
+- Funds move to a fresh address only you control
 - Original key exposure doesn't matter after sweep
 
 ```bash
-bitcoin-cli sweepprivkeys '["5KJvs..."]' "bc1q_your_address"
+bitcoin-cli sweepprivkeys '{"privkeys": ["5KJvs..."]}'
 ```
 
 ### What is Codex32?
@@ -253,7 +254,7 @@ No. Knots doesn't modify the mining algorithm or proof-of-work. It only affects 
 
 ### What mining pool uses Knots?
 
-[Ocean](https://ocean.xyz/), co-founded by Luke Dashjr, runs Bitcoin Knots. It's backed by Jack Dorsey and reportedly processed $500M+ in mining.
+[Ocean](https://ocean.xyz/), co-founded by Luke Dashjr, runs Bitcoin Knots. It's backed by a $6.2M seed round led by Jack Dorsey, and Tether directs hashrate to it as part of its ~$500M mining expansion.
 
 ---
 
@@ -372,7 +373,7 @@ No. Filtering is:
 
 ### What's the OP_RETURN controversy?
 
-In 2025, Bitcoin Core v30 removed the 80-byte limit on OP_RETURN data. Critics (including Nick Szabo, who broke 5 years of silence) warned this:
+In 2025, Bitcoin Core v30 effectively removed the limit on OP_RETURN data. Critics (including Nick Szabo, who broke five years of silence on X to comment) warned this:
 - Increases attack surface for data storage abuse
 - Changes Bitcoin's character from money to data layer
 - Was done without broad community consensus

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 7
 title: External Resources
 description: Node statistics, dashboards, and monitoring tools
 ---
@@ -36,12 +36,12 @@ This shows all nodes running Knots 29.2.0 (November 2025 release).
 
 ## Current Adoption
 
-As of early 2025, based on coin.dance data:
+As of mid-2026, based on coin.dance data:
 
-- **Bitcoin Core**: ~18,600 nodes (78%)
-- **Bitcoin Knots**: ~5,100+ nodes (21%+)
+- **Bitcoin Core**: ~18,400 nodes (~77%)
+- **Bitcoin Knots**: ~5,400 nodes (~23%)
 
-Knots adoption increased significantly following the OP_RETURN controversy in mid-2025.
+Knots adoption increased significantly following the OP_RETURN controversy in mid-2025, crossing 20% of the network in September 2025.
 
 ## Official Resources
 

--- a/docs/reference/rpc.md
+++ b/docs/reference/rpc.md
@@ -25,7 +25,7 @@ Bitcoin Knots includes all Bitcoin Core RPC commands plus additional Knots-speci
 |---------|-------------|
 | `getmempoolinfo` | Mempool statistics (enhanced in Knots) |
 | `getrawmempool` | List mempool transactions |
-| `listmempooltxs` | List mempool txs (Knots) |
+| `listmempooltransactions` | List mempool txs (Knots) |
 | `getmempoolentry` | Mempool entry details |
 
 ## Network


### PR DESCRIPTION
## Summary

Resolves the factual concerns flagged in #5. Five research agents verified every flagged claim against primary sources: the Bitcoin Knots source tree at tag `v29.3.knots20260508`, Bitcoin Core release notes, the BIP repository (BIP-93, BIP-110), and news/primary coverage. 30 files changed; the Docusaurus build passes.

## Confirmed bugs fixed

**Would-be misconfigurations (worst offenders):**
- `dustrelayfee=3000` etc. — these options parse as BTC/kvB decimals, so 3000 would mean 3,000 BTC per kvB. Corrected to `0.00003`-style values with unit comments.
- `bytespersigopstrict=1` weakens the check ~20x; default is 20.
- `mempoolfullrbf` is boolean — the "0=never, 1=optin, 2=always" comment described Knots' separate `mempoolreplacement` option (`0` / `fee,optin` / `fee,-optin`), now documented correctly.

**Nonexistent commands/flags removed or corrected:**
- `listmempooltxs` → `listmempooltransactions`; `sweepprivkeys` takes an options object and sweeps into the loaded wallet (no destination param); `importcodex32`/`validatecodex32` don't exist — codex32 import goes through `importdescriptors`' `seeds` parameter (verified in src/wallet/rpc/backup.cpp); `importfromcoldcard` is a `bitcoin-wallet` tool command, not an RPC; no `loadwallet` salvage parameter; no `bitcoin-cli -testconfig`; no `BITCOIN_DATADIR`/`BITCOIN_CLI_ARGS` env vars; `gen=1` was removed upstream in 0.13.
- assumeutxo: mainnet support since Core v28, used via the `loadtxoutset` RPC, not a startup flag.

**Build docs:** Core/Knots are CMake-only since v29 — replaced all `./autogen.sh`/`./configure`/`make check` instructions with `cmake -B build` / `ctest`; dropped `libssl-dev` (OpenSSL removed in 0.20) and `bsdmainutils`; binaries now at `build/bin/`.

**BIP-110 page:** expiry is 52,416 blocks after activation (latest: block 1,018,080, ~Sept 2027) — the old block 987,424 figure came from the superseded BIP-444 draft and contradicted the page's own timeline; 55% is the *early lock-in* threshold while mandatory signaling guarantees activation (no timeout, no FAILED state); release history extended through v0.4.1 (March 2026); clarified the activation client is a standalone Knots-based fork, not part of official Knots (knots#238 closed unmerged).

**Version-history corrections:** legacy wallet removed in Core v30 not v24 (creation deprecated v26); UPnP removed in v29 not v28; Core `datacarriersize` was configurable with default 83 (not "fixed 80"), raised to 100,000 in v30; Knots went 42 → 83 in the November 29.2 release.

**Filtering semantics:** `rejecttokens` filters Runes (OP_RETURN OP_13) and OLGA/Stamps — not BRC-20, which are witness inscriptions; `rejectparasites` (on by default) targets CAT21 specifically — fixed a config example that said the opposite.

**Numbers & history:** architecture pages now agree on the real diff stats (interpreter.cpp +68/−22 — SigHashCache + optional policy check, not "comments only"; validation.cpp +551/−199); FAQ code-size table gained the missing "Other" row so columns sum to the stated totals; adoption stats updated to mid-2026 (~5,400 nodes, ~23%, 20% crossed Sept 2025); Ocean funding corrected ($6.2M Dorsey-led seed; the $500M is Tether's mining buildout); Knots name origin pinned to the "whip of knots" (John 2:15) account from Bitcoin Magazine 2016; unsourced Szabo blockquote paraphrased; PR #34214 dated January 2026; `torcontrol` default is 127.0.0.1:9051; `-softwareexpiry` takes a POSIX timestamp; macOS "System Settings" paths; keyserver.ubuntu.com is Canonical's Hockeypuck server, not "the SKS pool"; codex32 threshold is 0 or 2-9 with erasure correction of 8 (13 consecutive).

Also resolves the duplicate `sidebar_position: 4` between faq.md and resources.md.

## Verification
- `npm run build` passes (includes broken-link checking)
- Source-level claims verified against `bitcoinknots/bitcoin@v29.3.knots20260508` via the GitHub API

Closes #5