### PR TITLE
Site-wide accuracy update: v29.3, RDTS, and source-verified fixes

### DIFF
--- a/docs/architecture/build-system.md
+++ b/docs/architecture/build-system.md
@@ -6,7 +6,7 @@ description: Building Bitcoin Knots from source
 
 # Build System
 
-Bitcoin Knots uses the same build system as Bitcoin Core, supporting both CMake and Autotools.
+Bitcoin Knots uses the same build system as Bitcoin Core. Since v29, the build system is **CMake only** (minimum CMake 3.22) — the old Autotools system (`autogen.sh` / `configure`) has been removed.
 
 ## Quick Build (Linux)
 
@@ -16,53 +16,55 @@ git clone https://github.com/bitcoinknots/bitcoin.git
 cd bitcoin
 git checkout 29.x-knots
 
-# Install dependencies (Debian/Ubuntu)
-sudo apt-get install build-essential libtool autotools-dev automake \
-  pkg-config bsdmainutils python3 libssl-dev libevent-dev \
-  libboost-dev libsqlite3-dev
+# Install build requirements (Debian/Ubuntu)
+sudo apt-get install build-essential cmake pkgconf python3
 
-# For Qt GUI, also install:
-sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev \
-  qttools5-dev-tools libqrencode-dev
+# Install required dependencies
+sudo apt-get install libevent-dev libboost-dev
+
+# SQLite is required for descriptor wallets
+sudo apt install libsqlite3-dev
+
+# For the Qt GUI, also install:
+sudo apt-get install qtbase5-dev qttools5-dev qttools5-dev-tools \
+  librsvg2-bin imagemagick libqrencode-dev
 
 # Build
-./autogen.sh
-./configure
-make -j$(nproc)
+cmake -B build
+cmake --build build -j$(nproc)
 ```
 
-## CMake Build (Preferred for v28+)
+Binaries are produced in `build/bin/` (e.g. `build/bin/bitcoind`).
+
+## Building with CMake (v29+, the only supported system)
 
 ```bash
-mkdir build && cd build
-cmake ..
-make -j$(nproc)
-```
-
-## Build Options
-
-### Configure Options
-
-```bash
-# Disable wallet
-./configure --disable-wallet
-
-# Disable GUI
-./configure --without-gui
-
-# Enable debug
-./configure --enable-debug
-
-# Static linking
-./configure --enable-static
+cmake -B build            # Configure (add -D options here)
+cmake --build build -j$(nproc)
 ```
 
 ### CMake Options
 
 ```bash
-cmake -DBUILD_WALLET=OFF ..
-cmake -DBUILD_GUI=OFF ..
-cmake -DCMAKE_BUILD_TYPE=Debug ..
+# Disable wallet
+cmake -B build -DENABLE_WALLET=OFF
+
+# Build the GUI (bitcoin-qt) — OFF by default
+cmake -B build -DBUILD_GUI=ON
+
+# Debug build
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+
+# Enable ZMQ notifications
+cmake -B build -DWITH_ZMQ=ON
+```
+
+Note that the GUI defaults to **off** (`BUILD_GUI=OFF`), so `-DBUILD_GUI=ON` is needed to build `bitcoin-qt`. The GUI uses Qt 5 by default; Qt 6 can be selected with `-DWITH_QT_VERSION=6`.
+
+To list all available options with help text:
+
+```bash
+cmake -B build -LH
 ```
 
 ## Dependencies
@@ -71,34 +73,39 @@ cmake -DCMAKE_BUILD_TYPE=Debug ..
 
 | Dependency | Purpose |
 |------------|---------|
-| Boost | General utilities |
-| libevent | Network events |
-| OpenSSL/LibreSSL | Cryptography |
+| Boost | General utilities (headers only) |
+| libevent | Networking, RPC/HTTP server |
+
+OpenSSL is **not** a dependency (it was removed upstream around Core 0.20).
 
 ### Optional
 
 | Dependency | Purpose |
 |------------|---------|
-| Qt5/Qt6 | GUI |
-| libqrencode | QR codes |
-| SQLite3 | Descriptor wallets |
-| BerkeleyDB | Legacy wallets |
-| ZMQ | Notifications |
+| SQLite3 | Descriptor wallets (required if wallet is enabled) |
+| Berkeley DB 4.8 | Legacy wallets (off by default, `-DWITH_BDB=ON`) |
+| Qt 5 (≥5.11.3) | GUI (Qt 6 ≥6.2 optional via `-DWITH_QT_VERSION=6`) |
+| libqrencode | QR codes in the GUI |
+| ZeroMQ | Notifications (`-DWITH_ZMQ=ON`) |
+| libminiupnpc | UPnP port mapping (`-DWITH_MINIUPNPC=ON`) |
+| systemtap-sdt | USDT tracepoints (`-DWITH_USDT=ON`) |
 
 ## Cross-Compilation
 
 Using the depends system:
 
 ```bash
-# Build dependencies for target
+# Build dependencies for the target platform
 cd depends
 make HOST=x86_64-w64-mingw32 -j$(nproc)
-
-# Configure with depends
 cd ..
-./configure --prefix=$PWD/depends/x86_64-w64-mingw32
-make -j$(nproc)
+
+# Configure with the generated toolchain file
+cmake -B build --toolchain depends/x86_64-w64-mingw32/toolchain.cmake
+cmake --build build -j$(nproc)
 ```
+
+See `depends/README.md` for the list of supported host platform triplets.
 
 ## Reproducible Builds (Guix)
 
@@ -112,13 +119,16 @@ Produces deterministic binaries that can be verified by multiple builders.
 
 ```bash
 # Unit tests
-make check
+ctest --test-dir build
+
+# Or run the unit test binary directly
+build/bin/test_bitcoin
 
 # Functional tests
-./test/functional/test_runner.py
+build/test/functional/test_runner.py
 
 # Specific test
-./test/functional/test_runner.py wallet_basic.py
+build/test/functional/test_runner.py wallet_basic.py
 ```
 
 ## See Also

--- a/docs/architecture/code-analysis.md
+++ b/docs/architecture/code-analysis.md
@@ -8,6 +8,10 @@ description: Objective analysis of Bitcoin Knots code differences from Core
 
 This page provides an objective, data-driven analysis of the code differences between Bitcoin Knots and Bitcoin Core. All numbers are verifiable by running `git diff` between the respective tags.
 
+:::info Analysis pinned to v29.2 vs Core 29.0
+The numbers on this page compare **Bitcoin Knots v29.2.knots20251110** against **Bitcoin Core v29.0**. The current release, **v29.3.knots20260508** (May 2026, based on Core 29.3), additionally ships the opt-in BIP-110 (RDTS) consensus ruleset (`consensusrules=rdts`, disabled by default), which is outside the scope of this analysis.
+:::
+
 ## The "40,000 Lines" Claim
 
 A common concern about Bitcoin Knots is that it contains "40,000 lines of code" beyond Core. This page examines that claim and provides context about what those lines actually do.
@@ -145,7 +149,7 @@ Primarily:
 | **Medium** | ~1,400 | ~4% | Consensus-adjacent but mostly policy/restored code |
 | **Remaining** | ~5,000 | ~14% | Misc (translations, contrib scripts, etc.) |
 
-**Consensus rule changes: 0%** — Knots follows identical consensus rules to Core.
+**Consensus rule changes in the analyzed v29.2 release: 0%** — v29.2 follows identical consensus rules to Core, and later releases do the same in their default configuration. (Since v29.3, an explicitly opt-in RDTS ruleset exists — off by default.)
 
 ## Key Insight: Policy ≠ Consensus
 
@@ -172,7 +176,7 @@ When evaluating the ~40k lines:
 - Many Knots patches are rejected Core PRs — they were reviewed, just not merged
 - Restored code (libconsensus, UPnP) was reviewed when originally in Core
 - Code has been reviewed post-merge by others (albeit poorly documented)
-- The 21% of nodes running Knots provides real-world testing
+- The large share of nodes running Knots (peaking around 25% in September 2025; roughly 23% as of July 2026) provides real-world testing
 
 **Consider what's configurable:**
 - Most policy additions can be disabled with `corepolicy=1`
@@ -214,13 +218,13 @@ The ~40,000 lines figure is roughly accurate. What matters is understanding that
 1. **~70% is GUI/tests/docs** — cannot affect consensus
 2. **~12% is wallet/RPC/policy** — affects your node only
 3. **~4% is consensus-adjacent** — mostly policy hooks and restored Core code
-4. **0% changes consensus rules** — Knots validates identically to Core
+4. **0% changes consensus rules in the analyzed v29.2 / default configuration** — Knots validates identically to Core unless you explicitly opt in to the v29.3+ RDTS ruleset
 
 The question isn't whether to trust 40,000 lines blindly. It's whether you trust:
 - A 14-year Bitcoin contributor
 - Code that's 70% GUI/tests/docs
 - Policy options you can disable
-- 21% of the network running it in production
+- Roughly 23% of the network (as of July 2026) running it in production
 
 ## See Also
 

--- a/docs/architecture/code-review.md
+++ b/docs/architecture/code-review.md
@@ -6,6 +6,10 @@ description: Independent technical review of Bitcoin Knots consensus-adjacent co
 
 # Code Review Report
 
+:::caution Review pinned to v29.2
+This review covers **Bitcoin Knots v29.2.knots20251110**. The current release, **v29.3.knots20260508** (May 2026), additionally ships the opt-in BIP-110 (RDTS) consensus rules (`consensusrules=rdts`, disabled by default). Those rules are outside the scope of this review.
+:::
+
 **Subject:** Bitcoin Knots v29.2.knots20251110 consensus-adjacent code
 **Compared against:** Bitcoin Core v29.0
 **Review date:** January 2026
@@ -24,7 +28,7 @@ This review was conducted using AI-assisted static code analysis. It is not a fo
 | `consensus/` | 3 | +94 | **None** |
 | `script/bitcoinconsensus.*` | 2 | +252 | **None** (restored Core code) |
 
-**Conclusion:** No consensus rule changes were identified. All modifications are either:
+**Conclusion:** No consensus rule changes were identified in v29.2.knots20251110, the release under review (and none apply in later releases' default configuration; v29.3's opt-in RDTS rules are outside this review's scope). All modifications are either:
 1. Policy options (configurable relay behavior)
 2. Performance optimizations
 3. Restored Bitcoin Core code
@@ -359,13 +363,13 @@ For high-stakes deployments, consider commissioning a formal security audit from
 
 ## Conclusion
 
-After systematic review of all consensus-adjacent code in Bitcoin Knots v29.2, **no consensus rule changes were identified**. The changes fall into well-defined categories:
+After systematic review of all consensus-adjacent code in Bitcoin Knots v29.2, **no consensus rule changes were identified in that release**. The changes fall into well-defined categories:
 
 1. **Policy options** — Configurable relay behavior that doesn't affect block validation
 2. **Performance optimizations** — Same results, faster computation
 3. **Restored Core code** — Previously reviewed code brought back for compatibility
 
-The claim that Knots contains "dangerous consensus changes" is **not supported by code examination**. Knots validates blocks identically to Bitcoin Core.
+The claim that Knots contains "dangerous consensus changes" is **not supported by examination of the v29.2 code**. Knots v29.2 validates blocks identically to Bitcoin Core, and later releases do the same in their default configuration — the opt-in RDTS ruleset added in v29.3 only takes effect if the operator explicitly sets `consensusrules=rdts`, and would need a separate review.
 
 ---
 

--- a/docs/architecture/codebase-structure.md
+++ b/docs/architecture/codebase-structure.md
@@ -25,18 +25,20 @@ bitcoin/
 
 ```
 src/
+├── common/              # Shared code between node, wallet, and tools
 ├── consensus/           # Consensus-critical code
 ├── crypto/              # Cryptographic primitives
 ├── index/               # Block and tx indexes
+├── init/                # Initialization contexts
 ├── interfaces/          # Interface definitions
+├── ipc/                 # Inter-process communication
 ├── kernel/              # libbitcoinkernel
-├── net/                 # Networking code
 ├── node/                # Node-specific code
 ├── policy/              # Mempool policy
 ├── primitives/          # Basic data structures
 ├── rpc/                 # RPC handlers
 ├── script/              # Script interpreter
-├── secp256k1/           # ECDSA library
+├── secp256k1/           # Elliptic-curve cryptography library (ECDSA and Schnorr)
 ├── support/             # Support utilities
 ├── univalue/            # JSON library
 ├── util/                # Utility functions
@@ -75,8 +77,9 @@ git show --stat <commit-hash>
 ~/.bitcoin/
 ├── bitcoin.conf         # Main configuration
 ├── debug.log            # Debug output
-├── wallet.dat           # Legacy wallet (if used)
 ├── wallets/             # Wallet directory
+│   └── <name>/          # One subdirectory per wallet
+│       └── wallet.dat   # Wallet database
 ├── blocks/              # Block data
 ├── chainstate/          # UTXO set
 └── peers.dat            # Known peers

--- a/docs/architecture/consensus-adjacent-code.md
+++ b/docs/architecture/consensus-adjacent-code.md
@@ -6,7 +6,11 @@ description: Detailed examination of Bitcoin Knots changes near consensus-critic
 
 # Consensus-Adjacent Code Deep Dive
 
-This page provides a detailed examination of the ~4% of Bitcoin Knots code changes that touch files near consensus-critical areas. While these files are "consensus-adjacent," the changes themselves do not alter Bitcoin's consensus rules.
+This page provides a detailed examination of the ~4% of Bitcoin Knots code changes that touch files near consensus-critical areas. While these files are "consensus-adjacent," the changes examined here do not alter Bitcoin's consensus rules.
+
+:::caution Analysis pinned to v29.2
+This page examines **Bitcoin Knots v29.2.knots20251110** against **Bitcoin Core v29.0**. The current release, **v29.3.knots20260508** (May 2026), additionally ships the opt-in BIP-110 (RDTS) consensus ruleset (`consensusrules=rdts`, disabled by default), which is outside the scope of this page. In its default configuration, v29.3 validates identically to Core.
+:::
 
 :::info Why This Matters
 Understanding what code is actually changed — and more importantly, what it does — is essential for evaluating Knots' safety. This page provides the technical detail that the [Code Analysis](/architecture/code-analysis) overview summarizes.
@@ -108,7 +112,7 @@ The `script/` directory contains Bitcoin's Script interpreter. Changes here coul
 | `descriptor.cpp` | Enhanced | More descriptor types |
 | `sign.cpp` | Enhanced | BIP-322 message signing |
 | `signingprovider.cpp` | Enhanced | Codex32 seed support |
-| `interpreter.cpp` | Minimal | Comments only |
+| `interpreter.cpp` | ~90 insertions | SigHashCache performance caching; optional SIGHASH_ALL policy check |
 
 ### Descriptor Enhancements
 
@@ -130,15 +134,18 @@ BIP-322 provides a standard way to sign messages with Bitcoin keys. It's used fo
 
 ### What's NOT Changed
 
-The core Script interpreter (`interpreter.cpp`) has minimal changes:
+The core Script interpreter (`interpreter.cpp`) has about 90 insertions, detailed in the [Code Review Report](/architecture/code-review):
+
+- **SigHashCache** — a performance cache for signature hash midstates; the hash computation itself is unchanged (same inputs produce identical outputs)
+- **Optional SIGHASH_ALL requirement** — an opt-in, more-restrictive *policy* check (`m_require_sighash_all`), disabled by default
 
 ```bash
 # Check interpreter changes
-git diff FETCH_HEAD..HEAD -- src/script/interpreter.cpp | wc -l
-# Result: Very few lines, mostly comments
+git diff FETCH_HEAD..HEAD -- src/script/interpreter.cpp
+# ~90 insertions: SigHashCache + optional policy check, no opcode changes
 ```
 
-Critical functions remain untouched:
+Neither change touches consensus script evaluation. Critical functions remain untouched:
 - `EvalScript()` — Script execution
 - `VerifyScript()` — Script verification
 - Opcode implementations
@@ -297,9 +304,9 @@ git diff FETCH_HEAD..HEAD --stat -- src/validation.cpp src/script/ src/consensus
 
 When evaluating consensus-adjacent code, ask:
 
-1. **Does it change validation rules?** → No
+1. **Does it change validation rules?** → No (in the v29.2 code examined here)
 2. **Does it change consensus parameters?** → No
-3. **Could it cause a network fork?** → No
+3. **Could it cause a network fork?** → No — not unless you explicitly opt in to the v29.3+ RDTS ruleset with `consensusrules=rdts`, which is off by default and outside this page's scope
 4. **Is it configurable/optional?** → Yes (mostly)
 5. **Was it reviewed?** → Yes (Core PRs, post-merge review)
 
@@ -309,7 +316,7 @@ If you want to commission a professional audit of Knots' consensus-adjacent code
 
 1. The scope is manageable (~1,400 lines)
 2. Focus on `validation.cpp` policy hooks
-3. Verify `interpreter.cpp` is unchanged
+3. Verify the `interpreter.cpp` changes are limited to the SigHashCache and the optional policy check
 4. Confirm consensus parameters match Core
 
 ## Verify Everything
@@ -344,14 +351,14 @@ git diff FETCH_HEAD..HEAD -- src/consensus/consensus.h
 
 ## Summary
 
-The ~1,400 lines of consensus-adjacent code in Knots:
+The ~1,400 lines of consensus-adjacent code in Knots v29.2:
 
-1. **Do not change consensus rules** — Block validation is identical to Core
+1. **Do not change consensus rules** — Block validation in v29.2 is identical to Core (as it is in later releases' default configuration)
 2. **Are primarily policy options** — Configurable relay behavior
 3. **Include restored Core code** — Already reviewed, just restored
 4. **Are independently verifiable** — Commands provided above
 
-The claim that Knots has "dangerous consensus changes" is not supported by code examination. The consensus-adjacent code adds policy flexibility while leaving actual consensus validation untouched.
+The claim that Knots has "dangerous consensus changes" is not supported by examination of the v29.2 code. The consensus-adjacent code adds policy flexibility while leaving actual consensus validation untouched. (The opt-in RDTS consensus ruleset added in v29.3 is a separate, explicitly-enabled feature not covered by this analysis.)
 
 ## See Also
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -27,7 +27,7 @@ Bitcoin Knots (patches applied)
 
 ### Consensus Engine
 
-The consensus engine validates blocks and transactions according to Bitcoin's rules. **This is identical to Bitcoin Core** - Knots makes no consensus changes.
+The consensus engine validates blocks and transactions according to Bitcoin's rules. **This is identical to Bitcoin Core by default** - in its default configuration, Knots makes no consensus changes. Since v29.3.knots20260508, Knots also ships an explicitly opt-in BIP-110 (RDTS) consensus ruleset (`consensusrules=rdts`), which is disabled by default.
 
 Key files:
 - `src/consensus/` - Consensus rules
@@ -90,8 +90,7 @@ Knots improvements:
 ## Build System
 
 Knots uses the same build system as Core:
-- CMake (primary, v28+)
-- Autotools (legacy)
+- CMake (the only supported build system since v29; requires CMake 3.22+)
 - Guix for reproducible builds
 
 ## See Also

--- a/docs/architecture/patch-management.md
+++ b/docs/architecture/patch-management.md
@@ -15,64 +15,76 @@ Bitcoin Knots maintains a large collection of patches on top of Bitcoin Core. Un
     │
     ├── Merges from upstream (bitcoin/bitcoin v29.x)
     │
-    └── Merges from patch branches:
+    └── Merges from topic branches:
         ├── dustdynamic-29.1+knots
         ├── rejecttokens-29.1+knots
         ├── qt_darkmode-29+knots
         └── ... (200+ patches)
 ```
 
+:::note Topic branches are not public heads
+The individual topic branches are generally **not published** as branch heads in the public repository. Their names and contents are visible through the merge commits on `29.x-knots` — use `git log --merges` to discover them.
+:::
+
 ## Patch Naming Convention
 
-Patches follow the pattern:
+Many topic branches follow the pattern:
 
 ```
 <name>-<core_version>+knots
 ```
 
-Examples:
+The convention is common but not universal — some branches are unversioned or use other suffixes. Observed examples from merge commits:
+
 - `dustdynamic-29.1+knots` - Dust dynamic for Core 29.1
-- `rbf_opts-29+knots` - RBF options for Core 29.x
-- `qt_darkmode-29+knots` - Dark mode for 29.x
+- `gui_peers_bump_setting_keys-29+k` - Abbreviated `+k` suffix
+- `knots_branding-29` - Version suffix without `+knots`
+- `softwareexpiry`, `enforce_checkpoints` - No version suffix at all
 
 ## Viewing Patches
 
 ### List All Patches
 
 ```bash
-git log --oneline upstream/v29.0..HEAD --grep="^Merge" | head -50
+# Add Core as a remote (matching the setup used in Code Analysis)
+git remote add core https://github.com/bitcoin/bitcoin.git
+git fetch core v29.0
+
+git log --oneline --merges FETCH_HEAD..HEAD | head -50
 ```
 
 ### Count Patches
 
 ```bash
-git log --oneline upstream/v29.0..HEAD --grep="^Merge" | wc -l
+git log --oneline --merges FETCH_HEAD..HEAD | wc -l
 ```
 
 ### Examine a Specific Patch
 
+Since topic branches aren't published as public heads, locate a patch through its merge commit:
+
 ```bash
-# Find commits for a patch
-git log --oneline --all --grep="dustdynamic"
+# Find the merge commit for a patch
+git log --oneline --merges --grep="dustdynamic"
 
 # Show the merge
 git show <merge-commit>
 
-# Show the actual changes
-git log --oneline dustdynamic-29.1+knots ^v29.0
+# List the commits the merge brought in
+git log --oneline <merge-commit>^1..<merge-commit>^2
 ```
 
 ## Patch Categories
 
-Patches are roughly categorized as:
+Branch names loosely indicate the area a patch touches. The mapping below is approximate — naming is informal and many branches don't fit any pattern. Prefixes observed in merge commits include `gui_`, `rpc_`, `wallet_`, and `qt_`:
 
-| Prefix/Pattern | Category |
-|----------------|----------|
-| `pol_*`, `reject*` | Policy |
+| Prefix/Pattern (observed) | Category |
+|---------------------------|----------|
+| `reject*` | Policy |
 | `wallet_*`, `sweep*` | Wallet |
 | `rpc_*` | RPC |
 | `qt_*`, `gui_*` | GUI |
-| `net_*`, `tor_*` | Networking |
+| `tor_*` | Networking |
 | `restore_*` | Restored features |
 | `fix_*` | Bug fixes |
 

--- a/docs/getting-started/differences-from-core.md
+++ b/docs/getting-started/differences-from-core.md
@@ -11,7 +11,7 @@ Bitcoin Knots includes numerous enhancements over Bitcoin Core. This page summar
 ## Consensus
 
 :::tip Important
-Bitcoin Knots follows **identical consensus rules** to Bitcoin Core. Your node will validate blocks exactly the same way.
+Bitcoin Knots follows **identical consensus rules** to Bitcoin Core **by default**. Your node will validate blocks exactly the same way. The one exception is the explicitly opt-in [BIP-110/RDTS soft fork](/guides/bip-110) added in v29.3 — see below.
 :::
 
 The differences are in:
@@ -20,17 +20,28 @@ The differences are in:
 - Additional features and RPC commands
 - User interface improvements
 
+### Consensus (opt-in)
+
+Since v29.3, Knots ships optional enforcement of the BIP-110 ReducedData Temporary Softfork (RDTS). It is **off by default** — you must explicitly opt in via configuration (or the GUI prompt):
+
+```ini title="bitcoin.conf"
+# Opt in to BIP-110/RDTS enforcement (Knots 29.3+, off by default)
+consensusrules=rdts
+```
+
+Without this setting, Knots validates blocks identically to Bitcoin Core. See the [BIP-110 guide](/guides/bip-110) for details.
+
 ## Policy Differences
 
 ### Mempool & Relay Policies
 
 | Feature | Bitcoin Core | Bitcoin Knots |
 |---------|--------------|---------------|
-| `datacarriersize` | Fixed 80 bytes | Configurable (default 83) |
+| `datacarriersize` | No limit since v30 (default 100kB); 83-byte scriptPubKey limit before v30 | Configurable (default 83, traditionally 42) |
 | `datacarriercost` | N/A | Configurable weight multiplier |
 | `rejecttokens` | N/A | Filter BRC-20/token transactions |
-| `rejectparasites` | N/A | Filter CAT21 spam transactions |
-| `bytespersigopstrict` | N/A | Stricter sigops enforcement |
+| `rejectparasites` | N/A | Filter CAT21 spam transactions (on by default) |
+| `bytespersigopstrict` | N/A | Minimum bytes per sigop in relayed/mined transactions (default 20) |
 | `dustdynamic` | N/A | Dynamic dust threshold |
 | `permitbarepubkey` | N/A | Bare pubkey output policy |
 
@@ -49,7 +60,7 @@ datacarriersize=42
 
 ### Legacy Wallet Support
 
-Bitcoin Core has deprecated legacy wallets. Knots maintains support:
+Bitcoin Core removed legacy (BDB) wallets entirely in Core 30. Knots maintains support:
 
 ```bash
 # Create a legacy wallet (Knots)
@@ -63,9 +74,8 @@ bitcoin-cli dumpprivkey <address>
 
 | Command | Description |
 |---------|-------------|
-| `sweepprivkeys` | Import and sweep private keys |
+| `sweepprivkeys` | Sweep funds from private keys into the wallet (p2wpkh/p2tr support since v29.3) |
 | `dumpmasterprivkey` | Export HD master private key |
-| `signmessagewithprivkey` | BIP-322 enhanced signing |
 
 ### Codex32 Support
 
@@ -77,13 +87,13 @@ Knots includes Codex32 seed phrase import for hardware wallet recovery.
 
 ```bash
 # List mempool transactions (Knots)
-bitcoin-cli listmempooltxs
+bitcoin-cli listmempooltransactions
 
 # Get block file locations
 bitcoin-cli getblocklocations <blockhash>
 
 # Fee histogram data
-bitcoin-cli getmempoolinfo
+bitcoin-cli getmempoolinfo true
 ```
 
 ### Enhanced Commands
@@ -110,22 +120,20 @@ bitcoin-cli createrawtransaction [...] # Additional fee options
 
 ### Enabling Dark Mode
 
-Dark mode is available in Qt preferences or via:
-
-```bash
-bitcoin-qt -style=fusion
-```
+Dark mode support is native in Knots: the GUI automatically detects your operating system's theme and adjusts its colors accordingly. No flags or extra configuration are required — just set your OS to a dark theme.
 
 ## Networking
 
 ### Tor Integration
 
-Knots includes built-in Tor subprocess management:
+Knots automatically launches Tor as a subprocess when it isn't already running — no configuration needed. The command used can be overridden with the hidden `-torexecute` option (default: `tor`):
 
 ```ini title="bitcoin.conf"
-# Enable embedded Tor (Knots)
-torsubprocess=1
+# Optional: override the Tor command Knots launches (default: tor)
+torexecute=/usr/local/bin/tor
 ```
+
+Since v29.3, Knots also enables Tor's onion-service proof-of-work (PoW) DoS defenses for your hidden service when the Tor daemon supports them.
 
 ### UPnP Support
 
@@ -136,18 +144,14 @@ UPnP was removed from Bitcoin Core but restored in Knots:
 upnp=1
 ```
 
-### V2 Transport Default
-
-Knots defaults to v2 encrypted transport where available.
-
 ## Mining
 
 ### Block Size Control
 
-The `-blockmaxsize` option was removed from Core but restored in Knots:
+The `-blockmaxsize` option was removed from Core but restored in Knots (default: 300000 bytes):
 
 ```ini title="bitcoin.conf"
-# Limit block size (bytes)
+# Limit block size (bytes; Knots default is 300000)
 blockmaxsize=750000
 ```
 
@@ -173,9 +177,6 @@ rejecttokens=1
 permitbarepubkey=0
 bytespersigop=20
 bytespersigopstrict=1
-
-# Privacy
-torsubprocess=1
 
 # Mining
 blockmaxsize=750000

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -10,25 +10,29 @@ This guide covers downloading and installing Bitcoin Knots on various platforms.
 
 ## Current Release
 
-**Version:** 29.2.knots20251110
-**Release Date:** November 10, 2025
-**Based on:** Bitcoin Core 29.2
+**Version:** 29.3.knots20260508
+**Release Date:** May 8, 2026
+**Based on:** Bitcoin Core 29.3
+
+:::info RDTS opt-in
+v29.3.knots20260508 is the first release to ship the [BIP-110/RDTS soft fork](/guides/bip-110) — strictly **opt-in** (GUI confirmation or `consensusrules=rdts`; disabled by default). A parallel build without RDTS support, v29.3.knots20260507, is also available for users who prefer a client that cannot enforce it at all.
+:::
 
 ## Download
 
 Official releases are available at:
 
-**[bitcoinknots.org/files/29.x/29.2.knots20251110/](https://bitcoinknots.org/files/29.x/29.2.knots20251110/)**
+**[bitcoinknots.org/files/29.x/29.3.knots20260508/](https://bitcoinknots.org/files/29.x/29.3.knots20260508/)**
 
 ### Available Packages
 
 | Platform | File | Notes |
 |----------|------|-------|
-| Linux (x86_64) | `bitcoin-29.2.knots20251110-x86_64-linux-gnu.tar.gz` | Most common |
-| Linux (ARM64) | `bitcoin-29.2.knots20251110-aarch64-linux-gnu.tar.gz` | Raspberry Pi 4+ |
-| macOS (Intel) | `bitcoin-29.2.knots20251110-x86_64-apple-darwin.tar.gz` | Intel Macs |
-| macOS (Apple Silicon) | `bitcoin-29.2.knots20251110-arm64-apple-darwin.tar.gz` | M1/M2/M3/M4 Macs |
-| Windows | `bitcoin-29.2.knots20251110-win64-setup.exe` | Installer |
+| Linux (x86_64) | `bitcoin-29.3.knots20260508-x86_64-linux-gnu.tar.gz` | Most common |
+| Linux (ARM64) | `bitcoin-29.3.knots20260508-aarch64-linux-gnu.tar.gz` | Raspberry Pi 4+ |
+| macOS (Intel) | `bitcoin-29.3.knots20260508-x86_64-apple-darwin.tar.gz` | Intel Macs |
+| macOS (Apple Silicon) | `bitcoin-29.3.knots20260508-arm64-apple-darwin.tar.gz` | M1/M2/M3/M4 Macs |
+| Windows | `bitcoin-29.3.knots20260508-win64-setup.exe` | Installer |
 
 ## Verify Downloads
 
@@ -38,31 +42,34 @@ Official releases are available at:
 
 ```bash
 # Download the checksum and signature files
-wget https://bitcoinknots.org/files/29.x/29.2.knots20251110/SHA256SUMS
-wget https://bitcoinknots.org/files/29.x/29.2.knots20251110/SHA256SUMS.asc
+wget https://bitcoinknots.org/files/29.x/29.3.knots20260508/SHA256SUMS
+wget https://bitcoinknots.org/files/29.x/29.3.knots20260508/SHA256SUMS.asc
 ```
 
 ### Step 2: Verify GPG Signature
 
-First, import Luke Dashjr's GPG key:
+Import the release signing keys from the official Bitcoin Knots Guix signature repository:
 
 ```bash
-# Import Luke's key from a keyserver
-gpg --keyserver hkps://keys.openpgp.org --recv-keys 0xE463A93F5F3117EEDE6C7316BD02942421F4889F
+# Import all builder keys from the official repository
+git clone https://github.com/bitcoinknots/guix.sigs
+gpg --import guix.sigs/builder-keys/*.gpg
 
-# Or from the SKS keyserver pool
-gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 0xE463A93F5F3117EEDE6C7316BD02942421F4889F
+# Refresh from a keyserver to pick up updated expiry dates
+gpg --keyserver hkps://keys.openpgp.org --refresh-keys
 ```
 
-**Luke Dashjr's key fingerprint:**
+**Luke Dashjr's key fingerprints** (from the [official builder-keys](https://github.com/bitcoinknots/guix.sigs/tree/knots/builder-keys)):
+
 ```
-E463 A93F 5F31 17EE DE6C  7316 BD02 9424 21F4 889F
+Personal:    93CB 4961 F69A 6508 2D44  1080 2CBA 8253 0896 55C3
+Codesigning: 1A3E 761F 19D2 CC77 85C5  502E A291 A2C4 5D0C 504A
 ```
 
-You can also find the key at:
+Cross-check these fingerprints against multiple independent sources:
+- The [Bitcoin Knots Guix signature repository](https://github.com/bitcoinknots/guix.sigs/tree/knots/builder-keys)
 - [keys.openpgp.org](https://keys.openpgp.org/search?q=luke%40dashjr.org)
-- Luke's personal website
-- Bitcoin Core's [trusted-keys](https://github.com/bitcoin-core/guix.sigs/tree/main/builder-keys) (Luke is a Core contributor)
+- Bitcoin Core's [builder-keys](https://github.com/bitcoin-core/guix.sigs/tree/main/builder-keys) (Luke is a Core contributor)
 
 Verify the signature:
 
@@ -73,7 +80,7 @@ gpg --verify SHA256SUMS.asc SHA256SUMS
 **Expected output:**
 ```
 gpg: Signature made [date]
-gpg:                using RSA key E463A93F5F3117EEDE6C7316BD02942421F4889F
+gpg:                using EDDSA key ...
 gpg: Good signature from "Luke Dashjr <luke@dashjr.org>"
 ```
 
@@ -85,12 +92,12 @@ Don't just look for "Good signature" — verify the key fingerprint matches. A m
 
 ```bash
 # Verify your download matches the checksum
-sha256sum -c SHA256SUMS 2>/dev/null | grep bitcoin-29.2.knots20251110-x86_64-linux-gnu.tar.gz
+sha256sum -c SHA256SUMS 2>/dev/null | grep bitcoin-29.3.knots20260508-x86_64-linux-gnu.tar.gz
 ```
 
 **Expected output:**
 ```
-bitcoin-29.2.knots20251110-x86_64-linux-gnu.tar.gz: OK
+bitcoin-29.3.knots20260508-x86_64-linux-gnu.tar.gz: OK
 ```
 
 ### Web of Trust
@@ -98,7 +105,7 @@ bitcoin-29.2.knots20251110-x86_64-linux-gnu.tar.gz: OK
 For additional verification, Luke's key is signed by several well-known Bitcoin developers. You can view the key's signatures:
 
 ```bash
-gpg --list-sigs 0xE463A93F5F3117EEDE6C7316BD02942421F4889F
+gpg --list-sigs 0x1A3E761F19D2CC7785C5502EA291A2C45D0C504A
 ```
 
 ### Quick Verification Script
@@ -107,9 +114,9 @@ gpg --list-sigs 0xE463A93F5F3117EEDE6C7316BD02942421F4889F
 #!/bin/bash
 # verify-knots.sh - Verify Bitcoin Knots download
 
-VERSION="29.2.knots20251110"
+VERSION="29.3.knots20260508"
 FILE="bitcoin-${VERSION}-x86_64-linux-gnu.tar.gz"
-LUKE_KEY="E463A93F5F3117EEDE6C7316BD02942421F4889F"
+LUKE_KEY="1A3E761F19D2CC7785C5502EA291A2C45D0C504A"
 
 # Download verification files
 wget -q "https://bitcoinknots.org/files/29.x/${VERSION}/SHA256SUMS"
@@ -150,22 +157,22 @@ Bitcoin software controls your money. A compromised binary could steal your fund
 
 ```bash
 # Extract the archive
-tar -xzf bitcoin-29.2.knots20251110-x86_64-linux-gnu.tar.gz
+tar -xzf bitcoin-29.3.knots20260508-x86_64-linux-gnu.tar.gz
 
 # Move binaries to system path (optional)
-sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-29.2.knots20251110/bin/*
+sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-29.3.knots20260508/bin/*
 ```
 
 ### Or Run from Directory
 
 ```bash
-cd bitcoin-29.2.knots20251110/bin
+cd bitcoin-29.3.knots20260508/bin
 ./bitcoind --version
 ```
 
 Expected output:
 ```
-Bitcoin Knots version v29.2.knots20251110
+Bitcoin Knots version v29.3.knots20260508
 ```
 
 ## macOS Installation
@@ -174,10 +181,10 @@ Bitcoin Knots version v29.2.knots20251110
 
 ```bash
 # Extract
-tar -xzf bitcoin-29.2.knots20251110-arm64-apple-darwin.tar.gz
+tar -xzf bitcoin-29.3.knots20260508-arm64-apple-darwin.tar.gz
 
 # Move to Applications (optional)
-mv bitcoin-29.2.knots20251110 /Applications/Bitcoin-Knots
+mv bitcoin-29.3.knots20260508 /Applications/Bitcoin-Knots
 ```
 
 ### First Run
@@ -188,7 +195,7 @@ macOS will require you to approve the application:
 
 ## Windows Installation
 
-1. Run the installer: `bitcoin-29.2.knots20251110-win64-setup.exe`
+1. Run the installer: `bitcoin-29.3.knots20260508-win64-setup.exe`
 2. Follow the installation wizard
 3. Choose installation directory (default: `C:\Program Files\Bitcoin`)
 
@@ -200,17 +207,16 @@ For advanced users who want to compile from source:
 # Clone the repository
 git clone https://github.com/bitcoinknots/bitcoin.git
 cd bitcoin
-git checkout v29.2.knots20251110
+git checkout v29.3.knots20260508
 
 # Install dependencies (Debian/Ubuntu)
-sudo apt-get install build-essential cmake pkg-config bsdmainutils \
-  python3 libssl-dev libevent-dev libboost-dev libsqlite3-dev
+sudo apt-get install build-essential cmake pkgconf \
+  python3 libevent-dev libboost-dev libsqlite3-dev
 
 # Build with CMake (v29+)
-mkdir build && cd build
-cmake ..
-make -j$(nproc)
-sudo make install
+cmake -B build
+cmake --build build -j$(nproc)
+sudo cmake --install build
 ```
 
 :::tip Build System Change
@@ -244,6 +250,9 @@ Running on unsupported systems is not recommended.
 
 | Version | Date | Notes |
 |---------|------|-------|
+| v29.3.knots20260508 | May 8, 2026 | Opt-in BIP-110/RDTS, dbcache auto-scaling, sweepprivkeys segwit/taproot + GUI dialog |
+| v29.3.knots20260507 | May 8, 2026 | Same as above, without RDTS support |
+| v29.3.knots20260210 | Feb 10, 2026 | Wallet bug fixes, P2P use-after-free fixes |
 | v29.2.knots20251110 | Nov 10, 2025 | CVE-2025-46598 fix, datacarriersize default increased |
 | v29.1.knots20250903 | Sep 3, 2025 | Ephemeral anchors, CMake migration, NAT-PMP default |
 | v28.1.knots20250305 | Mar 5, 2025 | Previous stable |

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -8,7 +8,7 @@ import ThemedImage from '@theme/ThemedImage';
 
 # Introduction to Bitcoin Knots
 
-Bitcoin Knots is an enhanced derivative of [Bitcoin Core](https://bitcoincore.org), the reference implementation of the Bitcoin protocol. Created and maintained by [Luke Dashjr](https://github.com/luke-jr) since 2011, Bitcoin Knots includes a collection of patches that add features, improve functionality, and provide additional configuration options not available in Bitcoin Core.
+Bitcoin Knots is an enhanced derivative of [Bitcoin Core](https://bitcoincore.org), the reference implementation of the Bitcoin protocol. Created by [Luke Dashjr](https://github.com/luke-jr) in 2011 and maintained by him with community contributors, Bitcoin Knots includes a collection of patches that add features, improve functionality, and provide additional configuration options not available in Bitcoin Core.
 
 ## History
 
@@ -21,9 +21,10 @@ The name "Knots" has a dual meaning — it both references the merging/tying tog
 - **2023**: Addressed the "Inscriptions" exploit (CVE-2023-50428)
 - **2023**: Luke Dashjr co-founded Ocean mining pool (which runs Knots)
 - **2025**: Adoption surged 638% as debates over OP_RETURN limits intensified
-- **November 2025**: Current release v29.2.knots20251110
+- **November 2025**: Release v29.2.knots20251110
+- **May 2026**: Current release v29.3.knots20260508 — the first release to ship the opt-in BIP-110/RDTS soft fork
 
-As of late 2025, Bitcoin Knots powers approximately 21% of all Bitcoin nodes — a significant share of the network's infrastructure.
+As of mid-2026, Bitcoin Knots powers roughly 23% of all reachable Bitcoin nodes (after peaking near 25% in late 2025) — a significant share of the network's infrastructure.
 
 ## What Makes Knots Different?
 
@@ -37,7 +38,7 @@ Bitcoin Knots follows the same consensus rules as Bitcoin Core — your node wil
 - **Conservative Defaults**: Knots defaults to filtering certain transaction types that Core allows
 
 :::info Consensus Compatibility
-Bitcoin Knots follows identical consensus rules to Bitcoin Core. Running Knots does not affect your node's ability to validate the blockchain correctly. The differences are purely in local policy and features.
+Bitcoin Knots follows identical consensus rules to Bitcoin Core by default. Running Knots does not affect your node's ability to validate the blockchain correctly. The one exception is the explicitly opt-in [BIP-110/RDTS soft fork](/guides/bip-110) introduced in v29.3 — it is off unless you enable it. Otherwise the differences are purely in local policy and features.
 :::
 
 ## Version Numbering
@@ -45,7 +46,7 @@ Bitcoin Knots follows identical consensus rules to Bitcoin Core. Running Knots d
 Bitcoin Knots versions track Bitcoin Core releases with an additional identifier:
 
 <ThemedImage
-  alt="Bitcoin Knots version numbering: 29.2.knots20251110"
+  alt="Bitcoin Knots version numbering: 29.3.knots20260508"
   sources={{
     light: '/img/version-numbering.svg',
     dark: '/img/version-numbering-dark.svg',
@@ -77,7 +78,7 @@ Bitcoin Knots takes a more conservative approach than Bitcoin Core regarding blo
 4. **Feature Inclusion**: Includes useful features that Core hasn't prioritized or has removed
 
 :::tip The OP_RETURN Controversy
-The philosophical differences between Knots and Core came to a head in 2025 with Bitcoin Core v30's controversial removal of OP_RETURN limits. Nick Szabo, Jimmy Song, and Luke Dashjr were among the prominent voices opposing the change. [Read the full story →](/guides/op-return-controversy)
+The philosophical differences between Knots and Core came to a head in 2025 with Bitcoin Core v30's controversial removal of OP_RETURN limits. Nick Szabo, Jimmy Song, and Luke Dashjr were among the prominent voices opposing the change. The fight has since moved to the [BIP-110/RDTS soft fork](/guides/bip-110), which shipped as an opt-in feature in Knots 29.3. [Read the full story →](/guides/op-return-controversy)
 :::
 
 ## Notable Features
@@ -87,7 +88,8 @@ The philosophical differences between Knots and Core came to a head in 2025 with
 | `-rejectparasites` | Filter CAT21 spam transactions (on by default) |
 | `-datacarriersize` | Configurable OP_RETURN limit (83 bytes default) |
 | `-corepolicy` | Single flag to use Bitcoin Core defaults instead |
-| Legacy Wallet | Maintained support (deprecated in Core) |
+| `-consensusrules` | Opt-in enforcement of the [BIP-110/RDTS soft fork](/guides/bip-110) (off by default, new in v29.3) |
+| Legacy Wallet | Maintained support (removed in Core 30) |
 | Embedded Tor | Built-in Tor subprocess management |
 | Dark Mode | GUI dark theme support |
 | Software Expiry | Warnings to keep your node updated |

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -42,8 +42,8 @@ bitcoin-cli getblockchaininfo
 On first run, your node will download and verify the entire blockchain. This takes:
 
 - **Time**: 6-24 hours depending on hardware and connection
-- **Disk Space**: ~600 GB for full node, ~10 GB for pruned node
-- **Bandwidth**: ~600 GB download
+- **Disk Space**: ~700 GB for full node (mid-2026), ~25 GB real footprint for a pruned node (the chainstate alone is ~12 GB)
+- **Bandwidth**: ~700 GB download
 
 ### Pruned Mode (Recommended for Limited Storage)
 
@@ -73,10 +73,12 @@ rpcuser=youruser
 rpcpassword=yourpassword
 
 # Performance
+# Note: since v29.3, dbcache auto-scales with system RAM when unset
 dbcache=4000
 maxconnections=40
 
 # Knots-specific: data carrier limit
+# (42 is the traditional Knots default; current releases default to 83)
 datacarriersize=42
 ```
 
@@ -131,7 +133,7 @@ bitcoin-cli getmempoolinfo
 
 ```bash
 # Get fee histogram (Knots feature)
-bitcoin-cli getmempoolinfo
+bitcoin-cli getmempoolinfo true
 ```
 
 ## Troubleshooting

--- a/docs/guides/bip-110.md
+++ b/docs/guides/bip-110.md
@@ -6,14 +6,15 @@ description: Understanding the temporary soft fork proposal to restrict arbitrar
 
 # BIP-110: The Reduced Data Soft Fork
 
-BIP-110 (originally called BIP-444) is a **temporary soft fork proposal** that would restrict arbitrary data storage on Bitcoin for approximately one year. It represents the most aggressive technical response to the OP_RETURN controversy.
+BIP-110, the **Reduced Data Temporary Softfork (RDTS)** — originally floated as "BIP-444" — is a temporary soft fork that would restrict arbitrary data storage on Bitcoin for approximately one year. It represents the most aggressive technical response to the OP_RETURN controversy.
 
-:::info Current Status
-- **Official designation**: BIP-110 (assigned December 2025)
+:::info Current Status (July 2026)
+- **Official designation**: [BIP-110](https://github.com/bitcoin/bips/blob/master/bip-0110.mediawiki) in the bitcoin/bips repository
 - **Author**: Dathon Ohm (pseudonymous)
-- **Activation client**: RC2 released January 3, 2026
-- **Signaling**: Begins December 1, 2025
-- **Threshold**: 55% miner support required
+- **Shipped in Bitcoin Knots**: v29.3.knots20260508 (May 2026) includes RDTS as an **opt-in** (`consensusrules=rdts`)
+- **Signaling**: live since March 2026, but minimal — roughly **0.31% of hashrate** (~5 EH/s of ~940 EH/s) as of late June 2026, almost entirely from Ocean pool
+- **Threshold**: 55% of blocks in a difficulty period (1,109 of 2,016) for early lock-in
+- **Next milestone**: mandatory signaling period at blocks 961,632–963,647 (early August 2026); activation at height 965,664 (~September 1, 2026)
 :::
 
 ## Background
@@ -32,39 +33,55 @@ The proposal was initially called "BIP-444" and contained controversial language
 | **Data push limits** | Max 256 bytes | Prevent large data pushes |
 | **Witness element limits** | Max 256 bytes | Restrict witness data |
 | **Witness version restrictions** | Only v0 and Taproot permitted | Block future witness abuse |
-| **Taproot annex restrictions** | Temporarily restricted | Prevent annex-based data |
+| **Taproot annex restrictions** | Annexes invalidated | Prevent annex-based data |
 | **Control block limits** | Max 257 bytes | Limit Taproot control blocks |
-| **Opcode restrictions** | Certain opcodes limited | Disable inscription techniques |
+| **Opcode restrictions** | OP_SUCCESS* and OP_IF/OP_NOTIF prohibited in Tapscripts | Disable inscription techniques |
 
 ### Key Features
 
-- **Temporary**: Auto-expires after ~1 year (block height 987,424)
-- **Grandfathered UTXOs**: Pre-existing outputs exempt from restrictions
-- **UASF mechanism**: User-activated, not miner-activated
+- **Temporary**: Auto-expires ~1 year after activation (block height 1,018,080)
+- **Grandfathered UTXOs**: Outputs created before activation exempt from restrictions
+- **Hybrid activation**: miner signaling with 55% early lock-in, plus a mandatory-signaling "flag day" fallback (UASF-style)
 - **Knots-based**: Built on Bitcoin Knots, not Core
 
 ## Activation Timeline
 
 ```
-Dec 1, 2025    Signaling begins (bit 4)
-               ↓
-               55% threshold (1,109/2,016 blocks)
-               ↓
-~Sept 1, 2026  Max activation (block 965,664)
-               ↓
-               ~52,416 blocks (~1 year)
-               ↓
-               Auto-expiry (unless extended)
+Dec 1, 2025      Signaling opens (bit 4)
+                 ↓
+                 Early lock-in if 55% (1,109/2,016 blocks) in any period
+                 — as of late June 2026, signaling is ~0.31% of hashrate
+                 ↓
+Blocks 961,632–  Mandatory signaling period (~early August 2026)
+963,647          ↓
+Block 963,648    Lock-in (no later than)
+                 ↓
+Block 965,664    Activation (~September 1, 2026)
+                 ↓
+Block 1,018,080  Auto-expiry (~52,416 blocks, ~1 year later)
 ```
 
-## The Activation Client
+## How to Run It
 
-### Release History
+### Bitcoin Knots v29.3 (the mainstream route)
+
+Since May 2026, the primary way to enforce BIP-110 is **Bitcoin Knots itself**: v29.3.knots20260508 ships RDTS as a strictly opt-in feature. Users must explicitly confirm adoption via a GUI prompt, or add to `bitcoin.conf`:
+
+```ini
+consensusrules=rdts
+```
+
+RDTS is **disabled by default**. A parallel build without any RDTS support (v29.3.knots20260507) is published for users who prefer a client that cannot enforce it at all.
+
+### The Standalone Activation Client
+
+Before Knots shipped RDTS, the pseudonymous author distributed a standalone activation client:
 
 | Version | Date | Status |
 |---------|------|--------|
 | **RC1** | December 10, 2025 | Buggy — severe criticism |
 | **RC2** | January 3, 2026 | Fixes applied |
+| **Knots v29.3.knots20260508** | May 8, 2026 | RDTS shipped opt-in in mainline Knots |
 
 ### RC1 Problems
 
@@ -150,36 +167,44 @@ Some observers compare BIP-110's rushed development to the failed SegWit2x fork 
 
 ## Current Miner Signaling
 
-As of January 2026, miner signaling for BIP-110 is minimal. The 55% threshold has not been approached.
+The first signaling blocks appeared in **March 2026**, and as of late June 2026 signaling stands at roughly **0.31% of network hashrate** (~5 EH/s out of ~940 EH/s) — nowhere near the 55% early lock-in threshold. Ocean pool has produced the large majority of signaling blocks; no other major pool has committed to signaling.
 
-Key mining pools have not publicly committed to supporting or opposing the proposal.
+Estimates of nodes running BIP-110-capable software range from **2% to 8%** of listening nodes, though the figures are disputed.
+
+With early lock-in out of reach, attention has shifted to the mandatory signaling period (blocks 961,632–963,647, ~early August 2026): nodes that have opted in will begin rejecting non-signaling blocks then, regardless of hashrate support. **Adam Back and Jameson Lopp have both publicly warned that these activation parameters risk a chain split**; Lopp's ["A Layman's Guide to BIP-110"](https://blog.lopp.net/a-laymans-guide-to-bip-110/) is one of the more thorough critical walkthroughs.
 
 ## Relationship to Bitcoin Knots
 
-BIP-110 is built on **Bitcoin Knots**, not Bitcoin Core. This is significant because:
+BIP-110 is built on **Bitcoin Knots**, not Bitcoin Core — and since v29.3.knots20260508 (May 2026), mainline Knots ships it as an opt-in. This is significant because:
 
 - Knots already has conservative defaults (83-byte OP_RETURN limit)
 - Knots users are the natural constituency for BIP-110
-- The ~21% of nodes running Knots represents the potential base
+- The roughly 23% of reachable nodes running Knots (July 2026) represents the potential base — though only an estimated 2–8% of listening nodes run BIP-110-capable software, and opting in is a further explicit step
 
-However, even many Knots supporters are skeptical of consensus-level restrictions, preferring policy-level solutions.
+However, even many Knots supporters are skeptical of consensus-level restrictions, preferring policy-level solutions. Knots' default configuration does **not** enforce RDTS.
 
-## What Happens If It Activates?
+## What Happens Next?
 
-**If BIP-110 activates** (55% miner support reached):
+**If 55% miner signaling is reached** (currently far off at ~0.31%):
+- Early lock-in, then activation one period later
 - Transactions violating the seven rules become invalid
 - Ordinals-style inscriptions would be blocked
-- Large OP_RETURN outputs would be rejected
-- Restrictions last ~1 year, then expire
+- Restrictions last ~1 year (to block 1,018,080), then expire
 
-**If it fails to activate**:
-- No consensus change occurs
+**The live scenario — flag-day activation without hashrate support:**
+- Opted-in nodes begin enforcing mandatory signaling at block 961,632 (~early August 2026) and the full restrictions at block 965,664 (~September 1, 2026)
+- If miners keep producing non-signaling blocks, opted-in nodes reject them while the rest of the network follows the majority chain — the chain-split scenario Back and Lopp warn about
+- How much economic weight is behind opted-in nodes at that point determines whether this is a non-event or a serious split
+
+**If it expires or fizzles**:
+- No lasting consensus change occurs
 - The debate continues at the policy level
 - Proponents may attempt a revised proposal
 
 ## How to Monitor
 
-- **Official site**: [bip110.org](https://bip110.org/)
+- **Official site**: [bip110.org](https://bip110.org/) (live signaling monitor at bip110.org/monitor)
+- **BIP text**: [bip-0110.mediawiki](https://github.com/bitcoin/bips/blob/master/bip-0110.mediawiki) in bitcoin/bips
 - **GitHub**: [dathonohm/bitcoin](https://github.com/dathonohm/bitcoin)
 - **Signaling**: Monitor bit 4 in block versions
 
@@ -191,7 +216,10 @@ However, even many Knots supporters are skeptical of consensus-level restriction
 
 ## Sources
 
+- [BIP-110 text (bitcoin/bips)](https://github.com/bitcoin/bips/blob/master/bip-0110.mediawiki)
 - [BIP-110 Official Site](https://bip110.org/)
+- [Bitcoin Knots v29.3.knots20260508 release notes](https://github.com/bitcoinknots/bitcoin/releases/tag/v29.3.knots20260508) — RDTS opt-in
+- [A Layman's Guide to BIP-110](https://blog.lopp.net/a-laymans-guide-to-bip-110/) — Jameson Lopp
 - [BIP-110 GitHub Repository](https://github.com/dathonohm/bitcoin)
 - [BIP-110 RC2 Release Notes](https://github.com/dathonohm/bitcoin/releases/tag/v29.2.knots20251110%2Bbip110-v0.1rc2)
 - [Bitcoin developers take shots at buggy BIP 110 client](https://blockspace.media/insight/dathon-ohm-releases-bip-110-client-for-uasf-softfork/) — Blockspace Media

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -43,16 +43,25 @@ maxconnections=125
 # Bind to specific IP
 bind=0.0.0.0
 
-# Use Tor
+# Use Tor: route outgoing connections through a Tor SOCKS proxy
 proxy=127.0.0.1:9050
-onlynet=onion
 
-# Knots: Enable embedded Tor
-torsubprocess=1
+# Accept incoming connections via a Tor onion service
+listenonion=1
+
+# Tor control host and port (default: 127.0.0.1:9051)
+torcontrol=127.0.0.1:9051
+
+# Only connect to .onion addresses
+onlynet=onion
 
 # Knots: Enable UPnP
 upnp=1
 ```
+
+:::tip Automatic Tor launch
+When built with subprocess support, Bitcoin Knots automatically launches Tor as a subprocess if onion listening is enabled and no already-running Tor daemon is reachable. The command used is controlled by the hidden `-torexecute=<command>` option (default: `tor`), so you normally only need `tor` installed — no manual `torrc` configuration required.
+:::
 
 ## RPC Configuration
 
@@ -60,7 +69,7 @@ upnp=1
 # Enable RPC server
 server=1
 
-# RPC credentials
+# RPC credentials (legacy method — prefer cookie auth or rpcauth below)
 rpcuser=bitcoinrpc
 rpcpassword=CHANGE_ME
 
@@ -72,10 +81,14 @@ rpcbind=0.0.0.0
 rpcauthfile=/path/to/rpcauth
 ```
 
+:::tip Prefer cookie auth or rpcauth
+If you don't set `rpcuser`/`rpcpassword`, bitcoind writes a random `.cookie` file to the data directory that local `bitcoin-cli` uses automatically — this is the safest default. For remote clients, use `rpcauth=<userpw>` (generated with the `share/rpcauth/rpcauth.py` script) or Knots' `rpcauthfile` instead of storing a plaintext password in `bitcoin.conf`.
+:::
+
 ## Performance
 
 ```ini title="bitcoin.conf"
-# Database cache (MB)
+# Database cache (MiB)
 dbcache=4000
 
 # Maximum mempool size (MB)
@@ -84,6 +97,10 @@ maxmempool=300
 # Block verification threads
 par=4
 ```
+
+:::note dbcache auto-scaling (v29.3+)
+Since v29.3, when `dbcache` is not set, Bitcoin Knots automatically selects a value based on available system memory — platform dependent, between 100 MiB and 2 GiB. Only set `dbcache` explicitly if you want a different size (e.g. a larger cache to speed up initial sync).
+:::
 
 ## Knots Policy Options
 
@@ -100,16 +117,35 @@ rejecttokens=1
 # Reject inscription transactions
 rejectparasites=1
 
-# Bytes per sigop
+# Equivalent bytes per sigop for relay and mining (default: 20)
 bytespersigop=20
-bytespersigopstrict=1
 
-# Dust settings
-dustdynamic=1
+# Minimum bytes per sigop in relayed/mined transactions (default: 20)
+bytespersigopstrict=20
 
-# Bare pubkey policy
+# Dynamic dust threshold (experimental; default: off)
+# Syntax: off | [<multiplier>*]target:<blocks> | [<multiplier>*]mempool:<kvB>
+# Example: raise dustrelayfee to the fee expected to confirm within 6 blocks
+dustdynamic=target:6
+
+# Bare pubkey policy (0 is already the default)
 permitbarepubkey=0
 ```
+
+## Consensus Rules (RDTS / BIP-110)
+
+New in v29.3.knots20260508: Bitcoin Knots ships opt-in support for the Rejecting Data Transaction Softfork (RDTS, BIP-110). The rules are **disabled by default** — you must explicitly opt in, either through the GUI confirmation dialog or in `bitcoin.conf`:
+
+```ini title="bitcoin.conf"
+# Opt in to enforcing the RDTS (BIP-110) consensus rules
+consensusrules=rdts
+```
+
+:::danger Consensus opt-in
+Enabling `consensusrules=rdts` changes how your node validates blocks — this is a change to **consensus validation**, not just relay policy. If the soft fork does not gain broad support across the network, nodes enforcing RDTS could follow a different chain than the rest of the network (a chain split). Do not opt in unless you understand and accept these implications. A parallel build without RDTS support (v29.3.knots20260507) is also available.
+:::
+
+See [BIP-110](/guides/bip-110) for a full explanation of the proposed rules.
 
 ## Wallet Options
 
@@ -130,12 +166,16 @@ changetype=bech32
 ## Mining Options (Knots)
 
 ```ini title="bitcoin.conf"
-# Maximum block size (Knots)
-blockmaxsize=750000
+# Maximum block size in bytes (Knots default: 300000)
+blockmaxsize=300000
 
 # Priority space for transactions
 blockprioritysize=50000
 ```
+
+:::warning Block size and mining income
+`blockmaxweight` is the preferred option since SegWit. Setting `blockmaxsize` to anything other than maximum will reduce your income — see the [Mining Guide](/guides/mining) for details and full-block configurations.
+:::
 
 ## Pruning
 
@@ -169,7 +209,8 @@ printtoconsole=1
 ```ini title="bitcoin.conf"
 server=1
 listen=1
-torsubprocess=1
+proxy=127.0.0.1:9050
+listenonion=1
 onlynet=onion
 rejecttokens=1
 rejectparasites=1

--- a/docs/guides/creating-a-fork.md
+++ b/docs/guides/creating-a-fork.md
@@ -17,15 +17,15 @@ Bitcoin's security model assumes no single entity controls the network. But what
 <div className="implementation-chart">
   <div className="chart-container">
     <div className="pie-chart">
-      <div className="slice core" style={{background: 'conic-gradient(#f7931a 0% 78%, #4a90a4 78% 100%)'}}></div>
+      <div className="slice core" style={{background: 'conic-gradient(#f7931a 0% 77%, #4a90a4 77% 100%)'}}></div>
     </div>
     <div className="chart-legend">
-      <div className="legend-item"><span className="dot core"></span> Bitcoin Core: ~78%</div>
-      <div className="legend-item"><span className="dot knots"></span> Bitcoin Knots: ~21%</div>
+      <div className="legend-item"><span className="dot core"></span> Bitcoin Core: ~77%</div>
+      <div className="legend-item"><span className="dot knots"></span> Bitcoin Knots: ~23%</div>
       <div className="legend-item"><span className="dot other"></span> All others: ~1%</div>
     </div>
   </div>
-  <p className="chart-source">As of January 2026 · Live data: <a href="https://coin.dance/nodes">coin.dance/nodes</a></p>
+  <p className="chart-source">As of July 2026 (Coin Dance: 22.7%; bitdis.org: 22.97%) · Live data: <a href="https://coin.dance/nodes">coin.dance/nodes</a></p>
 </div>
 
 This is a **monoculture problem**. When ~99% of nodes run code from two closely-related implementations:
@@ -79,7 +79,7 @@ Most successful implementations started as personal projects. Build something yo
 
 ### The Scenario
 
-Bitcoin Core v30 removed the standardness limit on OP_RETURN outputs. Previously, the default was 80 bytes. Now there's effectively no limit enforced at the policy level.
+Bitcoin Core v30 raised the default standardness limit on OP_RETURN outputs from 80 bytes of data to **100,000 bytes**, and marked the `-datacarrier`/`-datacarriersize` options as deprecated. The policy limit still technically exists, but at 100 kB it no longer meaningfully constrains data storage.
 
 You might:
 - Disagree with this change
@@ -108,10 +108,11 @@ OP_RETURN limits are **policy only** — safe to modify.
 
 We're going to restore the pre-v30 behavior:
 
-| Setting | Core v29 | Core v30 | Our Fork |
-|---------|----------|----------|----------|
-| Default `datacarriersize` | 83 | Unlimited | 83 |
-| OP_RETURN relay | Limited | Unlimited | Limited |
+| Setting | Core v29 | Core v30+ | Our Fork |
+|---------|----------|-----------|----------|
+| Default `datacarriersize` | 83 | 100,000 bytes | 83 |
+| `-datacarrier`/`-datacarriersize` options | Supported | Deprecated | Supported |
+| OP_RETURN relay | Limited | Effectively unconstrained | Limited |
 
 This is a one-line change that affects default behavior while still allowing users to override it via configuration.
 
@@ -119,26 +120,29 @@ This is a one-line change that affects default behavior while still allowing use
 
 You'll need:
 - **Git** — Version control
-- **Build tools** — Compiler, make, etc.
+- **Build tools** — CMake (3.22+) and a C++ compiler
 - **Dependencies** — Libraries Bitcoin Core needs
-- **~50GB disk space** — For source, build artifacts, and blockchain
+- **~50GB disk space** — For source, build artifacts, and regtest testing (a synced **mainnet** node additionally needs ~700 GB for the full blockchain, or ~25 GB pruned)
 - **2-4 hours** — For first build (faster on subsequent builds)
 
 ### Install Build Dependencies
 
+Since v29, Bitcoin Core builds with **CMake** (autotools is gone), and from v30 the GUI requires **Qt 6**.
+
 **Ubuntu/Debian:**
 ```bash
 sudo apt-get update
-sudo apt-get install -y build-essential libtool autotools-dev automake pkg-config bsdmainutils python3
+sudo apt-get install -y build-essential cmake pkgconf python3
 sudo apt-get install -y libevent-dev libboost-dev libsqlite3-dev
-sudo apt-get install -y libminiupnpc-dev libnatpmp-dev libzmq3-dev
-# For GUI (optional)
-sudo apt-get install -y qtbase5-dev qttools5-dev-tools
+# Optional: ZMQ notifications
+sudo apt-get install -y libzmq3-dev
+# For GUI (optional, Qt 6)
+sudo apt-get install -y qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools
 ```
 
 **macOS:**
 ```bash
-brew install automake libtool boost pkg-config libevent qt@5 miniupnpc libnatpmp zeromq
+brew install cmake boost pkgconf libevent sqlite qt@6 zeromq
 ```
 
 **For other systems**, see [Core's build documentation](https://github.com/bitcoin/bitcoin/tree/master/doc).
@@ -163,8 +167,8 @@ git tag -l 'v3*' | tail -10
 Choose a recent stable release as your base:
 
 ```bash
-# Check out the latest stable release (example: v30.0)
-git checkout v30.0
+# Check out the latest stable release (example: v31.0)
+git checkout v31.0
 
 # Create your fork branch
 git checkout -b my-policy-fork
@@ -173,7 +177,9 @@ git checkout -b my-policy-fork
 git branch
 ```
 
-**Naming convention suggestion:** `v30.0-mypolicy` or `v30.0-opreturn-limit`
+As of mid-2026, **v31.0** is the latest stable release; the 30.x series is maintained at **v30.2** if you prefer an older base.
+
+**Naming convention suggestion:** `v31.0-mypolicy` or `v31.0-opreturn-limit`
 
 ## Step 3: Find the Code to Change
 
@@ -188,7 +194,7 @@ grep -rn "MAX_OP_RETURN" src/
 grep -rn "nMaxDatacarrierBytes" src/
 ```
 
-In Bitcoin Core v30, the key files are:
+In Bitcoin Core v30 and later, the key files are:
 
 - `src/policy/policy.h` — Default constants
 - `src/policy/policy.cpp` — Policy implementation
@@ -205,12 +211,11 @@ cat src/policy/policy.h | head -80
 
 ### Understanding the Current Code
 
-In Core v30, you'll find something like:
+In Core v30 and later, you'll find something like:
 
-```cpp title="src/policy/policy.h (Core v30 - simplified)"
-/** Maximum size of OP_RETURN scripts we relay and mine */
-static constexpr unsigned int MAX_OP_RETURN_RELAY = MAX_SCRIPT_SIZE;
-// Or it may be effectively unlimited
+```cpp title="src/policy/policy.h (Core v30+ - simplified)"
+/** Default for -datacarriersize */
+static constexpr unsigned int MAX_OP_RETURN_RELAY{100'000};
 ```
 
 In earlier versions (v29 and before):
@@ -282,11 +287,11 @@ cat > doc/my-policy-changes.md << 'EOF'
 
 This fork restores the pre-v30 OP_RETURN data carrier size limit.
 
-## Changes from Bitcoin Core v30.0
+## Changes from Bitcoin Core v31.0
 
 ### 1. OP_RETURN Size Limit (src/policy/policy.h)
 
-- **Before (Core v30):** Effectively unlimited
+- **Before (Core v30+):** 100,000 bytes by default
 - **After (this fork):** 83 bytes (80 bytes of data)
 
 This is a **policy-only** change. It affects:
@@ -325,7 +330,7 @@ Nodes running this fork will:
 
 To update this fork when Core releases a new version:
 1. Fetch upstream: `git fetch origin`
-2. Rebase: `git rebase v30.1` (or merge)
+2. Rebase: `git rebase v31.1` (or merge)
 3. Resolve conflicts in policy.h
 4. Rebuild and test
 
@@ -353,54 +358,49 @@ Rationale: [Your reason]"
 
 ## Step 7: Build Your Fork
 
-### Generate Build System
-
-```bash
-# Run autogen (creates configure script)
-./autogen.sh
-```
+Bitcoin Core uses **CMake** (since v29) — there is no `autogen.sh` or `./configure` anymore.
 
 ### Configure
 
 ```bash
-# Basic build (no GUI)
-./configure --disable-gui --disable-tests --disable-bench
+# Basic build (no GUI, no tests)
+cmake -B build -DBUILD_TESTS=OFF
 
-# With GUI
-./configure --with-gui=qt5
+# With GUI (Qt 6)
+cmake -B build -DBUILD_GUI=ON
 
 # See all options
-./configure --help
+cmake -B build -LH
 ```
 
 **Recommended for first build:**
 ```bash
-./configure --disable-tests --disable-bench --with-gui=no
+cmake -B build -DBUILD_TESTS=OFF
 ```
 
 ### Compile
 
 ```bash
 # Use all CPU cores
-make -j$(nproc)
+cmake --build build -j$(nproc)
 
 # Or specify core count
-make -j4
+cmake --build build -j4
 ```
 
-This takes 30-90 minutes depending on your hardware.
+This takes 30-90 minutes depending on your hardware. Binaries land in `build/bin/`.
 
 ### Verify Build
 
 ```bash
-# Check the binary exists
-ls -la src/bitcoind src/bitcoin-cli
+# Check the binaries exist
+ls -la build/bin/bitcoind build/bin/bitcoin-cli
 
 # Check version
-./src/bitcoind --version
+./build/bin/bitcoind --version
 
 # Verify your change is present
-./src/bitcoind -help | grep datacarriersize
+./build/bin/bitcoind -help | grep datacarriersize
 ```
 
 ## Step 8: Test Your Fork
@@ -412,50 +412,53 @@ ls -la src/bitcoind src/bitcoin-cli
 mkdir -p /tmp/bitcoin-test
 
 # Start in regtest mode (private test network)
-./src/bitcoind -regtest -datadir=/tmp/bitcoin-test -daemon
+./build/bin/bitcoind -regtest -datadir=/tmp/bitcoin-test -daemon
 
 # Wait a moment, then test RPC
-./src/bitcoin-cli -regtest -datadir=/tmp/bitcoin-test getblockchaininfo
+./build/bin/bitcoin-cli -regtest -datadir=/tmp/bitcoin-test getblockchaininfo
 
 # Check your policy setting
-./src/bitcoin-cli -regtest -datadir=/tmp/bitcoin-test getnetworkinfo
+./build/bin/bitcoin-cli -regtest -datadir=/tmp/bitcoin-test getnetworkinfo
 
 # Stop the node
-./src/bitcoin-cli -regtest -datadir=/tmp/bitcoin-test stop
+./build/bin/bitcoin-cli -regtest -datadir=/tmp/bitcoin-test stop
 ```
 
 ### Test the OP_RETURN Limit
 
 ```bash
 # Start regtest node
-./src/bitcoind -regtest -datadir=/tmp/bitcoin-test -daemon
+./build/bin/bitcoind -regtest -datadir=/tmp/bitcoin-test -daemon
 sleep 2
 
 # Create a wallet and generate some coins
-./src/bitcoin-cli -regtest -datadir=/tmp/bitcoin-test createwallet "test"
-./src/bitcoin-cli -regtest -datadir=/tmp/bitcoin-test -generate 101
+./build/bin/bitcoin-cli -regtest -datadir=/tmp/bitcoin-test createwallet "test"
+./build/bin/bitcoin-cli -regtest -datadir=/tmp/bitcoin-test -generate 101
 
 # Create an OP_RETURN transaction with 80 bytes of data (should work)
 # This requires more complex scripting - see Bitcoin Core's functional tests
 # for examples of creating OP_RETURN transactions
 
 # Cleanup
-./src/bitcoin-cli -regtest -datadir=/tmp/bitcoin-test stop
+./build/bin/bitcoin-cli -regtest -datadir=/tmp/bitcoin-test stop
 rm -rf /tmp/bitcoin-test
 ```
 
 ### Run Automated Tests (Optional but Recommended)
 
 ```bash
-# Rebuild with tests enabled
-./configure --enable-tests
-make -j$(nproc)
+# Rebuild with tests enabled (the default)
+cmake -B build -DBUILD_TESTS=ON
+cmake --build build -j$(nproc)
 
 # Run unit tests
-make check
+ctest --test-dir build
+
+# Run the functional test suite
+./build/test/functional/test_runner.py
 
 # Run specific policy tests
-./test/functional/mempool_datacarrier.py
+./build/test/functional/mempool_datacarrier.py
 ```
 
 ## Step 9: Install Your Fork
@@ -463,7 +466,7 @@ make check
 ### Option A: Install System-Wide
 
 ```bash
-sudo make install
+sudo cmake --install build
 ```
 
 This installs to `/usr/local/bin/`. Your system's `bitcoind` is now your fork.
@@ -472,20 +475,20 @@ This installs to `/usr/local/bin/`. Your system's `bitcoind` is now your fork.
 
 ```bash
 # Add to your PATH
-export PATH="$HOME/bitcoin-dev/bitcoin/src:$PATH"
+export PATH="$HOME/bitcoin-dev/bitcoin/build/bin:$PATH"
 
 # Or create aliases
-alias bitcoind-custom="$HOME/bitcoin-dev/bitcoin/src/bitcoind"
-alias bitcoin-cli-custom="$HOME/bitcoin-dev/bitcoin/src/bitcoin-cli"
+alias bitcoind-custom="$HOME/bitcoin-dev/bitcoin/build/bin/bitcoind"
+alias bitcoin-cli-custom="$HOME/bitcoin-dev/bitcoin/build/bin/bitcoin-cli"
 ```
 
 ### Option C: Parallel Installation
 
 ```bash
-# Install with a different prefix
-./configure --prefix=$HOME/bitcoin-custom
-make -j$(nproc)
-make install
+# Configure with a different install prefix
+cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/bitcoin-custom
+cmake --build build -j$(nproc)
+cmake --install build
 
 # Run with explicit path
 ~/bitcoin-custom/bin/bitcoind
@@ -508,21 +511,22 @@ git tag -l 'v3*' | tail -5
 
 # Option A: Rebase onto new version (cleaner history)
 git checkout my-policy-fork
-git rebase v30.1
+git rebase v31.1
 
 # Option B: Merge new version (preserves history)
 git checkout my-policy-fork
-git merge v30.1
+git merge v31.1
 
 # Resolve any conflicts in policy.h
 # The conflict will likely be straightforward - just keep your value
 
-# Rebuild
-make clean
-./autogen.sh
-./configure [your options]
-make -j$(nproc)
+# Rebuild from scratch
+rm -rf build
+cmake -B build [your options]
+cmake --build build -j$(nproc)
 ```
+
+(Substitute whatever the newest tag actually is — e.g. a future v31.x point release, or v30.2 if you track the 30.x series.)
 
 ### Tracking Changes
 
@@ -533,12 +537,12 @@ cat >> doc/my-policy-changes.md << 'EOF'
 
 ## Changelog
 
-### v30.1-mypolicy (2025-XX-XX)
-- Rebased onto Bitcoin Core v30.1
+### v31.1-mypolicy (2026-XX-XX)
+- Rebased onto Bitcoin Core v31.1
 - No additional changes
 
-### v30.0-mypolicy (2025-XX-XX)
-- Initial fork from Bitcoin Core v30.0
+### v31.0-mypolicy (2026-XX-XX)
+- Initial fork from Bitcoin Core v31.0
 - Restored 83-byte OP_RETURN default
 
 EOF
@@ -621,13 +625,13 @@ After going through this process, you might appreciate why Bitcoin Knots exists:
 | Your testing only | Community tested |
 | No GUI improvements | Dark mode, mempool stats, etc. |
 
-**Knots already includes the OP_RETURN limit** (and makes it configurable):
+**Knots already includes the OP_RETURN limit** (and makes it configurable). Knots traditionally defaulted `datacarriersize` to 42; current releases temporarily default to 83:
 
 ```ini title="bitcoin.conf (Knots)"
-# Knots: Set OP_RETURN limit (default respects traditional limit)
+# Knots: Set OP_RETURN limit explicitly (or the stricter traditional 42)
 datacarriersize=83
 
-# Or use Core-compatible unlimited policy
+# Or use Core-compatible permissive policy
 corepolicy=1
 ```
 

--- a/docs/guides/mining.md
+++ b/docs/guides/mining.md
@@ -6,7 +6,7 @@ description: Mining configuration with Bitcoin Knots
 
 # Mining with Bitcoin Knots
 
-Bitcoin Knots is the node software powering [Ocean](https://ocean.xyz/), the decentralized mining pool co-founded by Luke Dashjr and backed by Jack Dorsey and Tether. This guide covers Knots-specific mining features and configuration.
+Bitcoin Knots is the node software powering [Ocean](https://ocean.xyz/), the decentralized mining pool co-founded by Luke Dashjr, whose 2023 seed round was led by Jack Dorsey's Block. This guide covers Knots-specific mining features and configuration.
 
 ## Why Miners Choose Knots
 
@@ -16,7 +16,8 @@ Ocean launched in 2023 with a mission to decentralize Bitcoin mining by giving m
 
 - **Runs Bitcoin Knots** as its node software
 - **Filters inscriptions** by default (configurable)
-- **Backed by** Jack Dorsey, Tether ($500M+ mining investment)
+- **Funding**: Jack Dorsey's Block led Ocean's $6.2M seed round (2023)
+- **Tether**: announced roughly $500M of investment in its own mining operations, and separately partnered with Ocean, deploying hashrate to the pool
 - **Headquarters** in El Salvador (2024)
 
 Dashjr's argument for filtering: "Spam-filtered blocks often have more fees anyway for some reason." The pool allows miners to construct their own templates, reducing reliance on centralized operators.
@@ -82,7 +83,7 @@ bitcoin-cli getblocktemplate '{
 **Parameters:**
 - `blockmaxsize` — Override configured block size limit
 - `blockmaxweight` — Override configured weight limit
-- `minfeerate` — Minimum fee rate (sat/vB) for inclusion
+- `minfeerate` — Only include transactions paying at least this fee rate, in sat/vB (default: set by `-blockmintxfee`)
 
 :::note Performance
 Setting per-call parameters disables template caching, which may reduce efficiency with multiple applications using `getblocktemplate`.
@@ -130,6 +131,19 @@ Critics argue filtering reduces miner income. Dashjr's response:
 > "Bitcoin works with the assumption that a majority of miners are honest, not malicious. Besides, spam-filtered blocks often have more fees anyway for some reason."
 
 The choice is yours — Knots provides the options, you decide the policy.
+
+## BIP-110/RDTS Signaling
+
+Miners who want to go beyond relay policy can signal for **BIP-110**, the Reduced Data Temporary Softfork (RDTS). Knots v29.3 ships RDTS enforcement as a strictly opt-in feature:
+
+```ini title="bitcoin.conf"
+# Opt in to enforcing the RDTS consensus rules (Knots v29.3+)
+consensusrules=rdts
+```
+
+GUI users are shown a consent prompt instead, and a separate non-RDTS build is published for those who decline. Ocean has been signaling for BIP-110 since around March 2026, though as of mid-2026 overall network signaling remains well below the 55% activation threshold.
+
+See **[BIP-110: The Reduced Data Soft Fork](/guides/bip-110)** for the full rules, activation timeline, and risks before opting in.
 
 ## Fee Configuration
 
@@ -217,19 +231,25 @@ blockmaxweight=4000000
 maxmempool=1000
 ```
 
-### Solo Mining (Testnet)
+### Test Mining (Regtest)
+
+For experimenting with block templates without real hashrate, use regtest — a private test network where you can generate blocks on demand:
 
 ```ini title="bitcoin.conf"
-# Testnet solo mining
-testnet=1
+# Regtest mining sandbox
+regtest=1
 server=1
-gen=1
 ```
 
 ```bash
-# Generate test blocks
-bitcoin-cli -testnet generatetoaddress 1 $(bitcoin-cli -testnet getnewaddress)
+# Create a wallet and generate test blocks to your own address
+bitcoin-cli -regtest createwallet "test"
+bitcoin-cli -regtest generatetoaddress 101 $(bitcoin-cli -regtest getnewaddress)
 ```
+
+:::note No built-in CPU mining
+The old `gen=1` internal miner was removed from Bitcoin long ago. On mainnet, blocks are found by external mining hardware pointed at your node (directly or via a pool); `generatetoaddress` only works on regtest and similar test networks.
+:::
 
 ## Performance Patches
 

--- a/docs/guides/op-return-controversy.md
+++ b/docs/guides/op-return-controversy.md
@@ -68,7 +68,9 @@ Bitcoin Core v30, released in October 2025, made significant policy changes:
 | OP_RETURN outputs per tx | 1 | Multiple allowed |
 | Default relay policy | Conservative | Permissive |
 
-The change was merged in June 2025 via [PR #32406](https://github.com/bitcoin/bitcoin/pull/32406) by maintainer Gloria Zhao, despite vocal opposition from many community members.
+The change was merged in June 2025 via [PR #32406](https://github.com/bitcoin/bitcoin/pull/32406) — authored by Gregory Sanders (instagibbs) and merged by maintainer Gloria Zhao — despite vocal opposition from many community members.
+
+Core has since moved on: as of mid-2026 the stable release is v31.0 (with 30.x maintained at 30.2), and the permissive OP_RETURN policy remains unchanged.
 
 ## The Case Against (Why Critics Say It's Harmful)
 
@@ -89,13 +91,15 @@ Critics argue Bitcoin was designed as "peer-to-peer electronic cash" — not a g
 
 ### 2. Blockchain Bloat and Node Costs
 
-Every byte stored on Bitcoin must be processed and stored by every full node forever. The numbers tell a stark story:
+Every byte stored on Bitcoin must be processed and stored by every full node forever. Community estimates circulated during the debate illustrate the trend:
 
-| Metric | 2009-2023 | By 2025 |
-|--------|-----------|---------|
-| UTXO set size | 4 GB (14 years) | 12 GB |
+| Metric | 2009-2023 | By 2025 (estimates) |
+|--------|-----------|---------------------|
+| UTXO set size | 4 GB (14 years) | ~12 GB |
 | UTXOs < 1000 sats | Minimal | ~49% of all UTXOs |
 | Ordinal-linked UTXOs | 0% | ~30% of all UTXOs |
+
+*Figures for 2025 are community estimates cited during the debate; exact percentages vary by methodology and measurement date.*
 
 This growth threatens decentralization by making it more expensive to run a node (disk space, RAM, bandwidth).
 
@@ -260,7 +264,7 @@ Libre Relay nodes preferentially peer with each other to form a parallel relay n
 
 **Chris Guida's Garbageman** (created at a hackathon) counters Libre Relay by having Knots nodes impersonate Libre Relay nodes. When Libre Relay nodes connect, expecting a friendly peer, the Garbageman node accepts the "spam" transactions — then discards them instead of relaying.
 
-~3,000 Bitcoin Knots nodes are running Garbageman, effectively sybil-attacking the Libre Relay network.
+As of late 2025, an estimated ~3,000 Bitcoin Knots nodes were running Garbageman, effectively sybil-attacking the Libre Relay network.
 
 ### Todd's Response
 
@@ -278,7 +282,14 @@ Some developers argued that policy-level changes weren't enough — **consensus-
 - **Mechanism**: UASF (User-Activated Soft Fork) requiring 55% miner support
 - **Duration**: ~1 year, then auto-expires
 - **Effect**: Seven consensus rules restricting data storage methods
-- **Status**: RC2 released January 3, 2026; minimal miner signaling so far
+- **Status**: Now an official BIP. Knots v29.3 ships RDTS enforcement as a strictly **opt-in** feature (`consensusrules=rdts` in the config, or a consent prompt in the GUI; a separate non-RDTS build is also published)
+
+### Activation Status (as of July 2026)
+
+- Miner signaling began around March 2026, led almost entirely by the Ocean pool
+- As of late June 2026, signaling stood at roughly **0.31% of hashrate** (~5 EH/s of ~940 EH/s) — far below the 55% threshold
+- The proposal's timeline includes a mandatory signaling period (blocks 961,632–963,647), lock-in by block 963,648 at the latest, and a flag day around **August 7, 2026**
+- **Adam Back** and **Jameson Lopp** have both warned that the activation parameters risk a chain split; Lopp published "A Layman's Guide to BIP-110" at blog.lopp.net
 
 ### Controversy
 
@@ -382,6 +393,8 @@ Notably, **Adam Back** (Blockstream CEO, Hashcash inventor) broke from other cri
 
 Back argued that "filters don't fix anything empirically" — though this contradicts the observable 850% growth in Knots nodes suggesting many operators disagree.
 
+In 2026, Back weighed in again from the same skeptical direction: together with Jameson Lopp, he warned that BIP-110's activation parameters risk a chain split (see the [BIP-110 guide](/guides/bip-110)).
+
 ## The Fallout
 
 The controversy had significant consequences on both sides:
@@ -444,12 +457,16 @@ Bitcoin Knots takes a fundamentally different approach: **defaults should embody
 
 ### Conservative Defaults
 
-| Option | Core v30 | Knots v29.2 |
+| Option | Core v30 | Knots v29.3 |
 |--------|----------|-------------|
 | `datacarriersize` | 100,000 bytes | **83 bytes** |
 | `rejectparasites` | Not available | **Enabled by default** |
 | `datacarriercost` | 0.25 | **1.0** (full cost) |
 | Philosophy | Neutral relay | Purpose-aligned relay |
+
+:::note About the 83-byte default
+Knots traditionally defaulted `datacarriersize` to **42 bytes**. Current releases temporarily default to **83 bytes** (80 bytes of data plus opcode overhead) — still a tiny fraction of Core's 100,000-byte default, and fully configurable either way.
+:::
 
 ### Key Protective Features
 
@@ -478,16 +495,17 @@ corepolicy=1
 
 This respects user autonomy while providing sensible defaults that align with Bitcoin's original purpose.
 
+The philosophy continues in current releases: Knots v29.3 adds a `subdustfeepenalty` policy (on by default, requiring higher fees from dust-creating transactions) and extends datacarrier bypass matching to newer injection schemes such as 'opnet'.
+
 ## Network Response
 
 The community voted with their nodes:
 
-| Metric | Early 2025 | Late 2025 |
-|--------|------------|-----------|
-| Bitcoin Knots nodes | ~2-4% | **~21%** |
-| Growth | — | **~850%** |
+| Metric | Early 2025 | Sept 2025 (peak) | July 2026 |
+|--------|------------|------------------|-----------|
+| Bitcoin Knots nodes | ~2-4% | **~25%** | **~23%** |
 
-This represents one of the largest shifts in node implementation share since Bitcoin's early days.
+Knots' share of reachable nodes grew roughly 850% during 2025, peaking around 25% in September 2025. It then gave back about a third of that peak before recovering to roughly 23% as of July 2026 (bitdis.org reports 22.97%; Coin Dance reports 22.7%). Even after the pullback, this represents one of the largest shifts in node implementation share since Bitcoin's early days.
 
 ## Why This Matters
 

--- a/docs/guides/running-a-node.md
+++ b/docs/guides/running-a-node.md
@@ -16,8 +16,12 @@ This guide covers setting up and operating a Bitcoin Knots full node.
 |----------|-------------|
 | CPU | 2+ cores |
 | RAM | 4 GB |
-| Storage | 10 GB (pruned) |
+| Storage | ~25 GB (pruned) |
 | Network | 10+ Mbps |
+
+:::note Pruned node footprint
+A pruned node's real disk usage is more than just the retained blocks: the chainstate (UTXO database) alone is around 12 GB as of mid-2026, plus indexes and undo data. Budget roughly 20-25 GB even with aggressive pruning. An unpruned node needs on the order of 700 GB for the full blockchain.
+:::
 
 ### Recommended
 
@@ -41,17 +45,24 @@ See [Installation Guide](/getting-started/installation).
 server=1
 daemon=1
 
-# RPC configuration
-rpcuser=bitcoinrpc
-rpcpassword=CHANGE_THIS_PASSWORD
+# RPC configuration (only needed for remote clients — see note below)
+#rpcauth=<userpw generated with share/rpcauth/rpcauth.py>
 
 # Performance
-dbcache=4000
 maxconnections=125
 
-# Knots-specific
+# Knots-specific (traditional Knots default; current releases
+# temporarily default to 83)
 datacarriersize=42
 ```
+
+:::tip Prefer cookie auth or rpcauth
+If you set no RPC credentials, bitcoind writes a random `.cookie` file to the data directory that local `bitcoin-cli` picks up automatically — this is the safest option for local use. For remote clients, use `rpcauth` (or Knots' `rpcauthfile`) rather than plaintext `rpcuser`/`rpcpassword` in `bitcoin.conf`.
+:::
+
+:::note dbcache
+Since Knots v29.3, leaving `dbcache` unset auto-scales the database cache to your system memory (between 100 MiB and 2 GiB). Setting a large value manually (e.g. `dbcache=4000` and up) is only worthwhile to speed up the initial block download on machines with plenty of RAM — well beyond the 4 GB minimum — and can be removed once synced.
+:::
 
 ### 3. Start the Node
 
@@ -134,8 +145,9 @@ cp ~/.bitcoin/bitcoin.conf ~/bitcoin-backup/
 
 1. Stop the node: `bitcoin-cli stop`
 2. Download new version
-3. Replace binaries
-4. Start node: `bitcoind -daemon`
+3. Verify the release signatures and checksums before installing — see [Verify Downloads](/getting-started/installation#verify-downloads)
+4. Replace binaries
+5. Start node: `bitcoind -daemon`
 
 ## Troubleshooting
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -50,8 +50,9 @@ bitcoind -printtoconsole
 **Symptom:** "Error reading configuration file"
 
 ```bash
-# Validate config file (Knots feature)
-bitcoin-cli -testconfig
+# Run in the foreground and read the startup error
+bitcoind -printtoconsole
+# The offending option and line are reported in the error message
 
 # Common syntax errors:
 # - Missing quotes around paths with spaces
@@ -64,7 +65,6 @@ bitcoin-cli -testconfig
 # These are valid in Knots but would error in Core:
 rejectparasites=1
 rejecttokens=1
-torsubprocess=1
 corepolicy=1
 ```
 
@@ -137,12 +137,17 @@ Look for `verificationprogress` — should increase steadily.
    bitcoin-cli getpeerinfo | grep -E '"addr"|"synced_blocks"'
    ```
 
-2. **Add seed nodes manually:**
+2. **Check outbound connectivity:**
    ```bash
-   bitcoin-cli addnode "seed.bitcoin.sipa.be" onetry
-   bitcoin-cli addnode "seed.btc.petertodd.org" onetry
-   bitcoin-cli addnode "seed.bitcoin.jonasschnelli.ch" onetry
+   # Verify DNS and outbound TCP work at all
+   bitcoin-cli getnetworkinfo | grep -E '"networks"|"reachable"'
+
+   # If you know a specific reliable peer, you can add it manually
+   bitcoin-cli addnode "<ip-or-hostname>:8333" onetry
    ```
+   If you have zero connections, check your firewall, proxy settings
+   (`proxy=`, `onlynet=`), and system clock — a badly skewed clock
+   causes peers to disconnect you.
 
 3. **Check for banned peers (may have banned good nodes):**
    ```bash
@@ -178,7 +183,8 @@ bitcoind
 Bitcoin Knots (like Core) can use significant RAM. Control with:
 
 ```ini title="bitcoin.conf"
-# Database cache (default: 450MB)
+# Database cache (v29.3+: auto-scaled by system RAM when unset,
+# between 100 MiB and 2 GiB)
 # Reduce for low-RAM systems
 dbcache=300
 
@@ -222,13 +228,15 @@ journalctl -xe | grep oom
 
 ### Disk Full
 
-**Current blockchain size:** ~600GB+ (unpruned)
+**Current blockchain size:** ~700GB (unpruned, as of mid-2026)
 
-**Option 1: Enable pruning (reduces to ~5-10GB)**
+**Option 1: Enable pruning**
 ```ini title="bitcoin.conf"
 # Keep 5GB of block data
 prune=5000
 ```
+
+Note that `prune` only limits block and undo data. The chainstate (UTXO set) alone is around 12GB, so expect a real on-disk footprint of roughly 20-25GB for a pruned node.
 
 :::warning Pruning Limitations
 Pruned nodes cannot:
@@ -245,11 +253,12 @@ ln -s /new/location/bitcoin ~/.bitcoin
 # Or use -datadir=/new/location
 ```
 
-**Option 3: Use assumeutxo (Knots/Core v29+)**
+**Option 3: Use assumeutxo (available since Core v26, supported in Knots)**
 ```bash
-# Fast-sync using a UTXO snapshot
-# Downloads and validates in background
-bitcoind -loadtxoutset=/path/to/snapshot.dat
+# Fast-sync using a UTXO snapshot: start bitcoind normally, then
+# load the snapshot via RPC. The node becomes usable at the snapshot
+# height while historical blocks validate in the background.
+bitcoin-cli loadtxoutset /path/to/snapshot.dat
 ```
 
 ### Slow Disk I/O
@@ -364,17 +373,13 @@ bitcoin-cli loadwallet "mylegacywallet"
 
 **Recovery steps:**
 
-1. **Try loading with salvage:**
+1. **Use the wallet tool to salvage (legacy wallets):**
    ```bash
-   bitcoin-cli loadwallet "walletname" false true  # load_on_startup=false, salvage=true
-   ```
-
-2. **Use wallet tool (legacy wallets):**
-   ```bash
+   # Run with bitcoind stopped; salvage attempts to recover keys
    bitcoin-wallet -wallet=~/.bitcoin/wallets/mylegacy salvage
    ```
 
-3. **Restore from backup:**
+2. **Restore from backup:**
    ```bash
    cp /backup/wallet.dat ~/.bitcoin/wallets/mylegacy/
    bitcoin-cli loadwallet "mylegacy"
@@ -398,13 +403,17 @@ bitcoin-cli testmempoolaccept '["0200000001..."]'
 | "txn-mempool-conflict" | Double spend in mempool | One version already there |
 
 **Knots filtering considerations:**
-```bash
-# If you're running Knots with filtering, check if that's the issue:
-bitcoin-cli getmempoolinfo | grep -E "rejectparasites|rejecttokens"
 
-# Test without filtering
-bitcoin-cli -corepolicy=1 testmempoolaccept '["rawtx"]'
+If you're running Knots with filtering and suspect your transaction is being rejected by Knots policy, temporarily test with Core-compatible policy. Policy options apply to `bitcoind`, not `bitcoin-cli` — the CLI only takes client connection options, so you must restart the node:
+
+```bash
+# Restart with Core-compatible policy defaults (or set corepolicy=1
+# in bitcoin.conf), then retry:
+bitcoind -corepolicy=1
+bitcoin-cli testmempoolaccept '["rawtx"]'
 ```
+
+To see which policy settings are in effect, check `bitcoind -help` for the options and their defaults, and review debug.log at startup — rejected transactions are logged with `debug=mempool` enabled.
 
 ### Stuck Unconfirmed Transaction
 
@@ -450,13 +459,7 @@ bitcoin-cli getnetworkinfo | grep -E '"connections|localaddresses"'
 
 ### Tor Connection Issues
 
-**Using Knots embedded Tor (recommended):**
-```ini title="bitcoin.conf"
-torsubprocess=1
-# Knots manages Tor automatically
-```
-
-**Manual Tor configuration:**
+**Tor configuration:**
 ```ini title="bitcoin.conf"
 # Proxy all connections through Tor
 proxy=127.0.0.1:9050
@@ -464,20 +467,39 @@ proxy=127.0.0.1:9050
 # Create hidden service
 listenonion=1
 
+# Tor control host and port (default: 127.0.0.1:9051)
+torcontrol=127.0.0.1:9051
+
 # Only connect to .onion addresses
 onlynet=onion
 ```
 
+When built with subprocess support, Knots launches Tor automatically if onion listening is enabled and no running Tor daemon is reachable — you just need `tor` installed and on the PATH (the command is configurable via the hidden `-torexecute` option, default: `tor`).
+
 **Debug Tor issues:**
 ```bash
-# Check if Tor is running
+# Is tor installed?
+which tor
+
+# Is a Tor daemon running?
 systemctl status tor
 # Or
 pgrep -a tor
 
+# Is the control port reachable? (default 127.0.0.1:9051)
+nc -zv 127.0.0.1 9051
+
+# Enable Tor logging in bitcoin.conf, then check debug.log
+# debug=tor
+grep -i tor ~/.bitcoin/debug.log | tail -20
+
 # Check onion address
 bitcoin-cli getnetworkinfo | grep onion
 ```
+
+:::note Onion service PoW defense (v29.3+)
+As of v29.3, Knots enables Tor's onion service proof-of-work DoS defense for the node's hidden service when the Tor daemon supports it, making it harder to flood your onion address with connection attempts.
+:::
 
 ### Banned by Many Peers
 

--- a/docs/guides/wallet-management.md
+++ b/docs/guides/wallet-management.md
@@ -88,9 +88,13 @@ bitcoin-cli -rpcwallet=wallet1 send '{
 
 ### Sweep Private Keys
 
+`sweepprivkeys` takes a single options object and sweeps all coins controlled by the given WIF private keys **into the loaded wallet** (it scans the UTXO set directly — no rescan needed):
+
 ```bash
-bitcoin-cli sweepprivkeys '["5K..."]' "bc1q..."
+bitcoin-cli -rpcwallet=wallet1 sweepprivkeys '{"privkeys": ["5K..."], "label": "swept coins"}'
 ```
+
+The destination and fee are handled by the wallet automatically; the call returns the sweep transaction id. As of Knots v29.3, sweeping covers legacy (P2PK/P2PKH), SegWit (P2WPKH and P2SH-P2WPKH), and Taproot (P2TR) outputs. The GUI also offers a **Sweep private key** dialog in the File menu.
 
 ### Dump Master Key (Legacy)
 
@@ -98,10 +102,12 @@ bitcoin-cli sweepprivkeys '["5K..."]' "bc1q..."
 bitcoin-cli -rpcwallet=legacy dumpmasterprivkey
 ```
 
-### Import Codex32
+### Import Codex32 Seeds
+
+Knots supports [codex32 (BIP 93)](/patches/wallet/codex32) seed backups via the `seeds` argument of `importdescriptors`. Pass a codex32-encoded seed (or a list of codex32 shares to be recombined) alongside the descriptors that use it:
 
 ```bash
-bitcoin-cli importcodex32 "ms1..."
+bitcoin-cli -rpcwallet=wallet1 importdescriptors '[{"desc": "wpkh(...)", "timestamp": "now"}]' '[["ms1..."]]'
 ```
 
 ## Backup
@@ -112,10 +118,28 @@ bitcoin-cli importcodex32 "ms1..."
 bitcoin-cli -rpcwallet=wallet1 backupwallet "/path/backup.dat"
 ```
 
+You can also export the descriptors themselves as a text backup. With `private=true`, the output includes private keys — sufficient to fully restore the wallet via `importdescriptors`:
+
+```bash
+# Public descriptors (watch-only backup)
+bitcoin-cli -rpcwallet=wallet1 listdescriptors
+
+# Include private keys (guard this output carefully)
+bitcoin-cli -rpcwallet=wallet1 listdescriptors true
+```
+
 ### Legacy Wallet
 
 ```bash
 bitcoin-cli -rpcwallet=legacy dumpwallet "/path/dump.txt"
+```
+
+### Migrating Legacy to Descriptor
+
+To convert a legacy wallet into a descriptor wallet (a backup of the original is created automatically before migration):
+
+```bash
+bitcoin-cli -rpcwallet=legacy migratewallet
 ```
 
 ## Security

--- a/docs/patches/gui/mempool-stats.md
+++ b/docs/patches/gui/mempool-stats.md
@@ -60,13 +60,16 @@ bitcoin-cli getmempoolinfo
 
 ### Enhanced getmempoolinfo (Knots)
 
-Knots adds a fee histogram to mempool info:
+Knots adds an optional fee-histogram argument to `getmempoolinfo`. Pass `true` for the default fee-rate buckets, or an array of custom bucket boundaries:
 
 ```bash
-bitcoin-cli getmempoolinfo
+bitcoin-cli getmempoolinfo true
+
+# Or with custom fee-rate buckets (sat/vB):
+bitcoin-cli getmempoolinfo '[0, 1, 2, 5, 10, 20, 50, 100]'
 ```
 
-The response includes fee distribution data not available in Bitcoin Core.
+The response then includes a `fee_histogram` object with fee distribution data not available in Bitcoin Core.
 
 ## Configuration
 
@@ -78,6 +81,13 @@ maxmempool=300
 
 # Mempool expiry in hours (default: 336 = 2 weeks)
 mempoolexpiry=336
+```
+
+Since Knots v29.3, the mempool allocation can also be changed at runtime — no restart required — with the new `maxmempool` RPC:
+
+```bash
+# Set the mempool allocation to 150 MB
+bitcoin-cli maxmempool 150
 ```
 
 ### Fee Estimation

--- a/docs/patches/gui/network-monitor.md
+++ b/docs/patches/gui/network-monitor.md
@@ -54,7 +54,6 @@ Click the network icon for quick stats.
 | **Services** | Node capabilities |
 | **Starting Height** | Peer's block height at connect |
 | **Sync Height** | Current synced height |
-| **Ban Score** | Misbehavior points |
 | **Ping** | Round-trip latency |
 | **Sent/Received** | Bandwidth usage |
 
@@ -210,8 +209,9 @@ bitcoin-cli getnettotals
 
 - **0 connections** — Network issue, check firewall
 - **Only outbound** — Ports not forwarded
-- **High ban scores** — May be misbehaving peer
 - **No Tor peers** — Consider enabling Tor
+
+(Note: the peer "ban score" / `misbehavior_score` field is deprecated — it is always 0, or 100 just before a peer is disconnected — so it is not useful as a live health metric.)
 
 ## Configuration Impact
 
@@ -220,11 +220,12 @@ Monitor shows effects of these settings:
 ```ini title="bitcoin.conf"
 # Connection limits
 maxconnections=125      # Total peer limit
-maxuploadtarget=1000    # Monthly upload limit (MB)
+maxuploadtarget=1000    # Upload target per 24 hours (MiB by default)
 
-# Network selection
-onlynet=ipv4           # Restrict to IPv4
-onlynet=onion          # Add Tor peers
+# Network selection: each onlynet= line adds a permitted network,
+# so together these restrict connections to IPv4 and Tor only
+onlynet=ipv4
+onlynet=onion
 
 # Peer management
 addnode=x.x.x.x        # Always try to connect

--- a/docs/patches/networking/tor-integration.md
+++ b/docs/patches/networking/tor-integration.md
@@ -6,7 +6,7 @@ description: Built-in Tor support for enhanced privacy in Bitcoin Knots
 
 # Tor Integration
 
-Bitcoin Knots includes enhanced Tor support with an embedded Tor subprocess — a feature that simplifies running your node over Tor without manual configuration.
+Bitcoin Knots includes enhanced Tor support, including the ability to launch Tor automatically as a subprocess — a feature that simplifies running your node over Tor without manual configuration.
 
 ## Why Use Tor?
 
@@ -47,22 +47,25 @@ With Tor:
 └─────────────┘     └─────────────┘     └─────────────┘
 ```
 
-## Knots Embedded Tor
+## Automatic Tor Launch (tor_subprocess patch)
 
 ### The Simple Way
 
-Bitcoin Knots can manage Tor automatically — no separate Tor installation needed:
+Bitcoin Knots can launch Tor automatically — you just need the `tor` binary installed. Whenever onion listening is enabled (`listenonion=1`, the default) and no Tor control port is reachable at `torcontrol` (default `127.0.0.1:9051`), Knots starts Tor itself as a subprocess:
 
 ```ini title="bitcoin.conf"
-# Enable embedded Tor subprocess
-torsubprocess=1
+# These are the defaults - shown for clarity
+listen=1
+listenonion=1
 ```
 
-That's it. Knots will:
-1. Start a Tor process automatically
+That's it. If Tor isn't already running, Knots will:
+1. Start a Tor process automatically (when built with Tor subprocess support)
 2. Configure it appropriately
 3. Create an onion service for your node
-4. Route connections through Tor
+4. Route onion connections through Tor
+
+For advanced use, the hidden option `-torexecute=<command>` (default: `tor`) controls the command used to launch Tor. Setting `torexecute=0` disables the automatic launch entirely.
 
 ### Verify It's Working
 
@@ -82,6 +85,10 @@ bitcoin-cli getnetworkinfo | jq '.localaddresses'
 #   }
 # ]
 ```
+
+### Onion Service PoW Defense (v29.3+)
+
+Starting with v29.3, onion services created by Knots request Tor's Proof-of-Work DoS defenses (`PoWDefensesEnabled=1`) when creating the onion service. If the connected Tor daemon doesn't support this feature, Knots automatically retries without it. This helps protect your node's onion service against denial-of-service floods.
 
 ## Manual Tor Configuration
 
@@ -144,11 +151,9 @@ Route **all** connections through Tor:
 # Only connect via Tor
 onlynet=onion
 proxy=127.0.0.1:9050
-
-# Or with embedded Tor
-torsubprocess=1
-onlynet=onion
 ```
+
+If Tor isn't already running, Knots launches it automatically as long as onion listening is enabled (see above).
 
 :::warning Tor-Only Tradeoffs
 - Slower initial sync (Tor bandwidth limited)
@@ -238,12 +243,12 @@ This encrypts peer connections, preventing ISPs from inspecting Bitcoin protocol
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `torsubprocess` | 0 | Enable embedded Tor |
 | `proxy` | none | SOCKS5 proxy for all connections |
 | `onion` | proxy | Separate proxy for .onion only |
 | `onlynet` | all | Restrict to specific networks |
 | `listenonion` | 1 | Create onion service |
-| `torcontrol` | none | Tor control port for auth |
+| `torcontrol` | 127.0.0.1:9051 | Tor control host and port |
+| `torexecute` | tor | Command to launch Tor if not running (hidden/advanced) |
 | `torpassword` | none | Tor control password |
 | `i2psam` | none | I2P SAM proxy address |
 | `i2pacceptincoming` | 1 | Accept inbound I2P |
@@ -253,7 +258,7 @@ This encrypts peer connections, preventing ISPs from inspecting Bitcoin protocol
 
 **Maximum Privacy (Tor-Only):**
 ```ini title="bitcoin.conf"
-torsubprocess=1
+# Knots auto-launches Tor when listenonion=1 (default)
 onlynet=onion
 dnsseed=0
 dns=0
@@ -261,8 +266,8 @@ dns=0
 
 **Balanced (Hybrid):**
 ```ini title="bitcoin.conf"
-torsubprocess=1
 listen=1
+listenonion=1
 ```
 
 **Performance Priority:**
@@ -290,7 +295,7 @@ tail -f ~/.bitcoin/debug.log | grep -i tor
 
 | Problem | Cause | Solution |
 |---------|-------|----------|
-| "Tor not found" | Tor not installed/running | Install Tor or use `torsubprocess=1` |
+| "Failed to execute Tor process" | Tor binary not installed | Install Tor (or point `torexecute` at the binary) |
 | "Control connection failed" | Wrong control port | Check torrc ControlPort |
 | "Authentication failed" | Cookie permissions | Add user to Tor group |
 | "No onion address" | listenonion disabled | Set `listenonion=1` |
@@ -313,7 +318,7 @@ bitcoin-cli getnetworkinfo | grep -E '"name"|"proxy"|"reachable"'
 
 ### Do
 
-- Use `torsubprocess=1` for simplicity
+- Let Knots auto-launch Tor for simplicity
 - Keep Tor updated
 - Use Tor-only for maximum privacy
 - Enable v2 transport for clearnet
@@ -347,10 +352,9 @@ Tor is slower than clearnet. For initial blockchain download:
 
 ```ini title="bitcoin.conf"
 # Sync over clearnet first
-# (comment out torsubprocess during IBD)
+# (leave onlynet unset during IBD)
 
-# After sync, enable Tor
-torsubprocess=1
+# After sync, restrict to Tor
 onlynet=onion
 ```
 

--- a/docs/patches/overview.md
+++ b/docs/patches/overview.md
@@ -18,12 +18,14 @@ Control what transactions your node relays and accepts into its mempool.
 
 | Patch | Purpose | Config Option |
 |-------|---------|---------------|
-| `rejecttokens` | Filter BRC-20/token transactions | `rejecttokens=1` (off by default) |
-| `rejectparasites` | Filter CAT21 spam transactions | `rejectparasites=1` **(on by default)** |
-| `dustdynamic` | Dynamic dust threshold | `dustdynamic=1` |
+| `rejecttokens` | Filter non-bitcoin token transactions (e.g. BRC-20) | `rejecttokens=1` (off by default) |
+| `rejectparasites` | Filter parasitic overlay protocols (currently CAT-21) | `rejectparasites=1` **(on by default)** |
+| `dustdynamic` | Dynamic dust threshold | `dustdynamic=off\|[<mult>*]target:<blocks>\|[<mult>*]mempool:<kvB>` (default: off) |
+| `subdustfeepenalty` | Reduce effective fee for sub-dust outputs — v29.3 | `subdustfeepenalty=1` **(on by default)** |
 | `datacarriercost` | Weight OP_RETURN data | `datacarriercost=<n>` |
+| `datacarrierfullcount` | Apply `datacarriersize` limit to all known datacarrier methods — updated in v29.3 to match newer bypass variations (incl. 'opnet') | `datacarrierfullcount=1` **(on by default)** |
 | `bytespersigopstrict` | Stricter sigops limits | `bytespersigopstrict=1` |
-| `unique_spk_mempool` | One tx per scriptPubKey | Enabled by default |
+| `unique_spk_mempool` | One unconfirmed tx per scriptPubKey | `spkreuse=conflict` (default: allow) |
 | `maxscriptsize` | Maximum script size | `maxscriptsize=<n>` |
 
 [Learn more about Policy Patches →](/patches/policy/mempool-policies)
@@ -53,7 +55,8 @@ Additional and enhanced RPC commands.
 
 | Patch | Purpose |
 |-------|---------|
-| `listmempooltxs` | List mempool transactions |
+| `listmempooltransactions` | List mempool transactions |
+| `maxmempool` | Change mempool memory allocation at runtime — v29.3 |
 | `getblocklocations` | Block file location info |
 | `fee_histogram` | Fee histogram in mempool info |
 | `getblockfileinfo` | Block file details |
@@ -109,17 +112,22 @@ Enhancements for miners.
 
 [Learn more about Mining →](/guides/mining)
 
+### Consensus
+
+New in v29.3: Bitcoin Knots ships the opt-in **Reduced Data Temporary Softfork (RDTS, BIP-110)**. It requires explicit confirmation — via the GUI startup prompt or by adding `consensusrules=rdts` to `bitcoin.conf`.
+
+[Learn more about BIP-110 →](/guides/bip-110)
+
 ### Restored Features
 
 Features removed from Bitcoin Core but maintained in Knots.
 
 | Feature | Removed in Core | Status in Knots |
 |---------|-----------------|-----------------|
-| Legacy Wallet | v24+ | Maintained |
+| Legacy Wallet | v30 | Maintained |
 | UPnP | v28 | Restored |
 | `-blockmaxsize` | v0.15 | Restored |
-| `libconsensus` | v28 | Restored |
-| Fee filter option | v24 | Restored |
+| `libconsensus` | v27 | Restored |
 
 ### Security & Checkpoints
 
@@ -138,7 +146,7 @@ Knots patches follow a naming convention:
 ```
 
 For example:
-- `dustdynamic-29.1+knots` - Dust dynamic patch for Core 29.1
+- `dustdynamic-29.3+knots` - Dust dynamic patch for Core 29.3
 - `rbf_opts-29+knots` - RBF options for Core 29.x
 
 ## Finding Specific Patches
@@ -164,10 +172,10 @@ git show <commit-hash>
 Most patches add **optional** configuration. Features are not forced on users:
 
 ```ini title="bitcoin.conf"
-# Enable inscription filtering (off by default)
-rejectparasites=1
+# Enable token filtering (off by default)
+rejecttokens=1
 
-# Disable if you want Core behavior
+# Disable the CAT-21 parasite filter (on by default) if you want Core behavior
 rejectparasites=0
 ```
 

--- a/docs/patches/policy/dust-and-fees.md
+++ b/docs/patches/policy/dust-and-fees.md
@@ -16,49 +16,71 @@ Bitcoin Knots provides enhanced control over dust thresholds and fee-related pol
 
 ### Static Dust Relay Fee
 
-Set the fee rate used to calculate dust threshold:
+Set the fee rate used to calculate the dust threshold. Like the other fee-rate options, it's expressed in BTC per 1000 virtual bytes (BTC/kvB):
 
 ```ini title="bitcoin.conf"
-# Satoshis per 1000 bytes
-dustrelayfee=3000
+# BTC per kvB (default: 0.00003, i.e. 3000 satoshis/kvB)
+dustrelayfee=0.00003
 ```
+
+An output is dust if spending it would cost more than its value at this fee rate.
 
 ### Dynamic Dust
 
-Enable dynamic dust calculation based on current fee rates:
+Automatically raise `dustrelayfee` based on current fee conditions (experimental):
 
 ```ini title="bitcoin.conf"
-dustdynamic=1
+# Syntax: off | [<multiplier>*]target:<blocks> | [<multiplier>*]mempool:<kvB>
+# Default: off
+
+# Track the fee estimate for confirmation within 6 blocks
+dustdynamic=target:6
+
+# Or track the feerate of the best 3000 kvB of your mempool
+dustdynamic=mempool:3000
 ```
 
-With dynamic dust enabled, the threshold adjusts based on mempool conditions.
+With dynamic dust enabled, the threshold adjusts to either the expected fee to be mined within `<blocks>` blocks, or the feerate needed to be within the best `<kvB>` kilo-vbytes of your node's mempool. If no multiplier is given, 3.0 is used.
 
 ## Fee Policies
 
 ### Minimum Relay Fee
 
-Set the minimum fee rate for transaction relay:
+Set the minimum fee rate for transaction relay. Fees below this are treated as zero fee for relaying, mining, and transaction creation:
 
 ```ini title="bitcoin.conf"
-# Satoshis per 1000 virtual bytes
-minrelaytxfee=1000
+# BTC per 1000 virtual bytes (default: 0.00001)
+minrelaytxfee=0.00001
 ```
 
 ### Incremental Relay Fee
 
-Fee increment required for RBF replacements:
+Fee rate used to define the cost of relay, applied to mempool limiting and replacement (RBF) policy:
 
 ```ini title="bitcoin.conf"
-incrementalrelayfee=1000
+# BTC per kvB (default: 0.00001)
+incrementalrelayfee=0.00001
+```
+
+### Sub-Dust Fee Penalty (v29.3+)
+
+New in v29.3: transactions creating sub-dust outputs have their effective fee reduced by the dust threshold for each sub-dust output, so dust-creating transactions need higher fees to compete:
+
+```ini title="bitcoin.conf"
+# Default: 1 (enabled)
+subdustfeepenalty=1
+
+# Disable the penalty
+subdustfeepenalty=0
 ```
 
 ### Confirmation Target Default
 
-Set default confirmation target (Knots patch):
+Set the default confirmation target used by the wallet for fee estimation (Knots patch):
 
 ```ini title="bitcoin.conf"
-# Default: 1 day (144 blocks)
-# Knots uses 1-day default vs Core's 6-block default
+# Knots default: 144 blocks (~1 day) vs Core's 6-block default
+txconfirmtarget=144
 ```
 
 ## Fee Estimation
@@ -73,21 +95,22 @@ bitcoin-cli savefeeestimates
 
 ### Accept Stale Estimates
 
-Allow using older fee estimates on mainnet:
+Allow reading fee estimates even if they are stale — **regtest only** (a debug/test option, not usable on mainnet):
 
 ```ini title="bitcoin.conf"
+# Regtest only; default: 0
 acceptstalefeeestimates=1
 ```
 
 ## Fee Histogram
 
-Knots includes fee histogram data in mempool info:
+Knots can include fee histogram data in mempool info when you pass the Knots-only argument:
 
 ```bash
-bitcoin-cli getmempoolinfo
+bitcoin-cli getmempoolinfo true
 ```
 
-Returns additional fee rate distribution data for better fee estimation.
+This returns a `fee_histogram` field with fee statistics grouped by fee rate ranges, useful for better fee estimation.
 
 ## See Also
 

--- a/docs/patches/policy/mempool-policies.md
+++ b/docs/patches/policy/mempool-policies.md
@@ -58,8 +58,9 @@ datacarriersize=42
 Control the maximum size of OP_RETURN outputs:
 
 ```ini title="bitcoin.conf"
-# Bitcoin Core default: 80 bytes
-# Knots default: 83 bytes (for legacy protocol compatibility)
+# Bitcoin Core before v30: 83-byte scriptPubKey (80 bytes of data)
+# Bitcoin Core v30+ (Oct 2025): limit removed (default 100,000 bytes)
+# Knots default: 83 bytes
 # Recommended for filtering: 42 bytes
 
 datacarriersize=42
@@ -79,21 +80,25 @@ datacarriercost=1.0
 
 ### Dynamic Dust Threshold
 
-Enable dynamic dust calculation based on fee rates:
+Automatically raise the dust fee rate based on current fee conditions (experimental, default `off`):
 
 ```ini title="bitcoin.conf"
-dustdynamic=1
+# Syntax: off | [<multiplier>*]target:<blocks> | [<multiplier>*]mempool:<kvB>
+dustdynamic=target:6
 ```
 
 This adjusts the dust threshold based on current fee conditions rather than using a fixed value.
 
-### Custom Dust Limit
+### Custom Dust Fee Rate
 
-Set a specific dust limit (in satoshis):
+Set the fee rate used to define dust, in BTC per 1000 virtual bytes (not a satoshi output limit):
 
 ```ini title="bitcoin.conf"
-dustrelayfee=3000
+# Default: 0.00003 BTC/kvB (3000 satoshis/kvB)
+dustrelayfee=0.00003
 ```
+
+An output counts as dust if spending it would cost more than its value at this fee rate.
 
 ## Sigops Policies
 
@@ -117,10 +122,12 @@ bytespersigopstrict=1
 
 ### Maximum Script Size
 
-Limit script sizes beyond consensus limits:
+Limit the size of scripts (including the entire witness stack) that your node relays and mines. The Knots default is 1650 bytes, so setting a higher value *loosens* the policy:
 
 ```ini title="bitcoin.conf"
-maxscriptsize=10000
+# Knots default: 1650 bytes
+# Lower values are stricter
+maxscriptsize=1650
 ```
 
 ### Bare Pubkey Outputs
@@ -128,6 +135,7 @@ maxscriptsize=10000
 Control bare pubkey (P2PK) output acceptance:
 
 ```ini title="bitcoin.conf"
+# Knots default (Core permits them)
 permitbarepubkey=0
 ```
 
@@ -135,31 +143,46 @@ permitbarepubkey=0
 
 ### RBF Mode Control
 
-Configure Replace-By-Fee behavior:
+Configure Replace-By-Fee behavior. `mempoolfullrbf` is a simple boolean (default `1`): accept replacements without requiring replaceability signaling:
 
 ```ini title="bitcoin.conf"
-# Options: 0=never, 1=optin, 2=always
+# Boolean, default: 1
 mempoolfullrbf=1
+```
+
+For finer control, Knots provides the three-way `mempoolreplacement` option:
+
+```ini title="bitcoin.conf"
+# 0           = disable RBF entirely
+# "fee,optin" = honour the RBF opt-out signal
+# "fee,-optin" = always allow RBF (full RBF) - default
+mempoolreplacement=fee,-optin
 ```
 
 ### TRUC Transaction Options
 
-Control Topologically Restricted Until Confirmation (v3) transactions:
+Control how your node treats transactions requesting TRUC (Topologically Restricted Until Confirmation, v3) limits:
 
 ```ini title="bitcoin.conf"
-# TRUC-specific options available via truc_opts patch
+# reject  = reject TRUC transactions entirely
+# accept  = treat them like any other transaction (default)
+# enforce = impose their requested restrictions
+mempooltruc=accept
 ```
 
 ## Mempool Limits
 
 ### Unique Script Per Mempool
 
-Limit to one unconfirmed transaction per output script:
+The `unique_spk_mempool` patch is controlled by the `spkreuse` option:
 
 ```ini title="bitcoin.conf"
-# Enabled by unique_spk_mempool patch
-# Helps prevent certain spam patterns
+# "allow"    = relay/mine transactions reusing addresses or other pubkey scripts (default)
+# "conflict" = treat reused scripts as exclusive prior to being mined
+spkreuse=conflict
 ```
+
+With `spkreuse=conflict`, only one unconfirmed transaction per output script is allowed at a time, which helps prevent certain spam patterns. (`corepolicy=1` sets `spkreuse=allow`.)
 
 ## Example Configurations
 
@@ -180,7 +203,7 @@ permitbarepubkey=0
 
 ```ini title="bitcoin.conf"
 # More permissive for fee revenue
-datacarriersize=80
+datacarriersize=83
 rejecttokens=0
 rejectparasites=0
 

--- a/docs/patches/policy/transaction-filtering.mdx
+++ b/docs/patches/policy/transaction-filtering.mdx
@@ -124,11 +124,17 @@ This is why `permitbaremultisig=0` is particularly important.
 | `rejectparasites` | **1** (on) | Filters CAT21 spam |
 | `rejecttokens` | 0 (off) | Filters Runes |
 | `datacarriersize` | 83 | Max OP_RETURN bytes |
-| `datacarriercost` | 1 | Weight multiplier for data |
-| `maxscriptsize` | varies | Max witness script size |
+| `datacarriercost` | 1 | Vbytes counted per data byte (1 = full cost, no witness discount) |
+| `datacarrierfullcount` | **1** (on) | Apply datacarriersize limit to all known datacarrier methods |
+| `maxscriptsize` | 1650 | Max script size (incl. witness stack) |
 | `permitbaremultisig` | **0** (off) | Blocks Stamps |
 | `acceptnonstddatacarrier` | **0** (off) | Strict OP_RETURN format |
 | `corepolicy` | 0 (off) | Use Core defaults instead |
+
+:::info What's new in v29.3
+- Datacarrier matching was updated to catch a newer bypass variation, and 'opnet' data is now recognized.
+- New `subdustfeepenalty` option (default on): sub-dust outputs reduce a transaction's effective fee by the shortfall, so dust-creating transactions need higher fees. See [Dust and Fees](/patches/policy/dust-and-fees).
+:::
 
 ### Detailed Options
 
@@ -144,7 +150,7 @@ rejectparasites=1
 rejectparasites=0
 ```
 
-Note: This option specifically targets CAT21 spam, not inscriptions or ordinals in general.
+Note: This option specifically targets CAT-21 spam (transactions with `nLockTime` set to 21), not inscriptions or ordinals in general. Inscription-envelope data is instead limited via `datacarrierfullcount` + `datacarriersize` (see below).
 
 #### rejecttokens
 
@@ -162,20 +168,17 @@ Detects OP_RETURN outputs starting with OP_13 (the Runes identifier). Updated in
 Maximum size of data in OP_RETURN outputs.
 
 ```ini title="bitcoin.conf"
-# Knots default (legacy compatibility)
+# Knots default (80 bytes of data + overhead)
 datacarriersize=83
 
-# Traditional limit (80 bytes of data)
-datacarriersize=83
-
-# Stricter (42 bytes - enough for hashes)
+# Stricter (42 bytes - enough for hashes; the traditional Knots value)
 datacarriersize=42
 
 # Disable all OP_RETURN relay
 datacarriersize=0
 ```
 
-**Why 83?** 1 byte OP_RETURN + 1-2 bytes pushdata + 80 bytes data = ~83 bytes.
+**Why 83?** 1 byte OP_RETURN + 2 bytes pushdata opcodes + 80 bytes data = 83 bytes.
 
 :::tip Filtering Runes
 Luke Dashjr's recommendation for filtering Runes: set `datacarriersize=0` in bitcoin.conf. [Source](https://x.com/LukeDashjr/status/1781749769431650700)
@@ -183,28 +186,48 @@ Luke Dashjr's recommendation for filtering Runes: set `datacarriersize=0` in bit
 
 #### datacarriercost
 
-Adjusts the "virtual size" calculation for data-carrying bytes, making data more expensive.
+Treats extra data in transactions as at least N vbytes per actual byte, adjusting the "virtual size" used for fee calculation.
 
 ```ini title="bitcoin.conf"
-# Default - data bytes count as 1 vbyte each
+# Knots default - each data byte counts as 1 full vbyte
+# (i.e. no witness discount for data)
 datacarriercost=1
 
-# Make data 4x more expensive (removes witness discount)
-datacarriercost=4
+# Core-equivalent witness discount (what corepolicy=1 sets)
+datacarriercost=0.25
 
-# Effectively prohibit large data (very expensive)
-datacarriercost=10
+# 4x penalty beyond full cost - data-heavy transactions
+# need much higher fees
+datacarriercost=4
 ```
 
-Higher values mean data-heavy transactions need higher fees to enter your mempool.
+Higher values mean data-heavy transactions need higher fees to enter your mempool. The default of `1` already counts data at full cost; values above 1 are an extra penalty.
+
+#### datacarrierfullcount
+
+Applies the `datacarriersize` limit to **all known datacarrier methods** (not just OP_RETURN), making it the central anti-bypass knob. **Enabled by default in Knots.**
+
+```ini title="bitcoin.conf"
+# Default in Knots - count data in inscription envelopes,
+# fake pubkeys, etc. against the datacarriersize limit
+datacarrierfullcount=1
+
+# Only apply the limit to OP_RETURN (Core-style; corepolicy=1 sets this)
+datacarrierfullcount=0
+```
+
+This is what makes `datacarriersize` effective against inscriptions and similar bypass techniques that store data outside OP_RETURN.
 
 #### maxscriptsize
 
-Limits the total witness script size per input.
+Limits the size of scripts your node relays and mines. **Default: 1650 bytes** — setting a larger value loosens the policy rather than tightening it.
 
 ```ini title="bitcoin.conf"
-# Limit witness scripts (targets large inscriptions)
-maxscriptsize=10000
+# Knots default - already restrictive
+maxscriptsize=1650
+
+# Stricter still
+maxscriptsize=1000
 ```
 
 In v29.1+, this applies to the **entire witness stack** of each input, closing evasion attempts.
@@ -253,7 +276,7 @@ Useful for testing or if you want Knots features but Core relay behavior.
 Used by [Ocean mining pool](https://ocean.xyz/):
 
 ```ini title="bitcoin.conf"
-# Inscriptions and ordinals
+# CAT-21 spam (default in Knots)
 rejectparasites=1
 
 # Runes and tokens
@@ -262,7 +285,11 @@ rejecttokens=1
 # Minimal OP_RETURN (or 0 to disable)
 datacarriersize=42
 
-# Remove witness discount for data
+# Apply the size limit to all datacarrier methods,
+# including inscription envelopes (default in Knots)
+datacarrierfullcount=1
+
+# 4x fee penalty for data bytes
 datacarriercost=4
 
 # Block Stamps
@@ -270,9 +297,6 @@ permitbaremultisig=0
 
 # Strict OP_RETURN format
 acceptnonstddatacarrier=0
-
-# Limit script sizes
-maxscriptsize=10000
 ```
 
 ### Moderate Filtering (Knots Default)
@@ -381,10 +405,12 @@ bitcoin-cli getblocktemplate '{"rules":["segwit"]}'
 - However, Dashjr notes "spam-filtered blocks often have more fees anyway"
 - [Ocean pool](https://ocean.xyz/) runs filtered and reports competitive revenue
 
-### Per-Template Overrides (v27.1+)
+### Per-Template Overrides (Knots-only)
+
+Knots' `getblocktemplate` accepts a `minfeerate` option: only include transactions paying at least this many sats/vbyte (defaults to the `-blockmintxfee` setting; using it disables the template cache):
 
 ```bash
-# Override policy for specific template
+# Only include transactions paying at least 10 sats/vbyte
 bitcoin-cli getblocktemplate '{
   "rules": ["segwit"],
   "minfeerate": 10

--- a/docs/patches/rpc/enhanced-commands.md
+++ b/docs/patches/rpc/enhanced-commands.md
@@ -10,57 +10,59 @@ Several existing Bitcoin Core RPC commands have enhanced functionality in Bitcoi
 
 ## getblocktemplate
 
-Extended options for miners:
+The `template_request` object accepts additional options for miners (from the `gbt_rpc_options` patch), letting a template be customized per request:
+
+| Option | Description |
+|--------|-------------|
+| `blockmaxsize` | Limit returned block to the specified size (bytes) |
+| `blockmaxweight` | Limit returned block to the specified weight |
+| `blockreservedsize` | Reserve size in the block for the generation transaction |
+| `blockreservedweight` | Reserve weight in the block for the generation transaction |
+| `blockreservedsigops` | Reserve sigops in the block for the generation transaction |
+| `minfeerate` | Only include transactions paying at least this many sats/vbyte |
 
 ```bash
 bitcoin-cli getblocktemplate '{
   "rules": ["segwit"],
-  "capabilities": ["proposal"],
-  "longpollid": "...",
-  "data": "..."
+  "blockmaxweight": 3000000,
+  "minfeerate": 2
 }'
 ```
 
-Additional parameters available through `gbt_rpc_options` patch.
-
-## createrawtransaction
-
-Enhanced fee handling options:
-
-```bash
-bitcoin-cli createrawtransaction '[...]' '{...}' 0 true
-```
+Using any of these options disables the template cache for that request.
 
 ## walletprocesspsbt
 
-Additional options for PSBT processing:
+Knots accepts an **options object** as the second argument (in place of the positional `sign` boolean), grouping the existing settings:
 
 ```bash
-bitcoin-cli walletprocesspsbt "psbt" true "ALL" true
+bitcoin-cli walletprocesspsbt "psbt" '{"sign": true, "sighashtype": "ALL", "bip32derivs": true, "finalize": true}'
 ```
+
+The Core-style positional form (`walletprocesspsbt "psbt" true "ALL" true`) is still accepted for backwards compatibility.
 
 ## descriptorprocesspsbt
 
-Enhanced with previous transaction support:
+Knots likewise accepts an options object as the third argument, and adds a `prevtxs` option — an array of dependent serialized transactions in hex, used to fill in input information that isn't available from the UTXO set or mempool:
 
 ```bash
-bitcoin-cli descriptorprocesspsbt "psbt" '[descriptors]' '{options}'
+bitcoin-cli descriptorprocesspsbt "psbt" '["descriptor1"]' '{"prevtxs": ["<raw tx hex>"]}'
 ```
 
 ## signmessage
 
-Enhanced with BIP-322 support for generic message signing:
+Enhanced with BIP-322 support: while Bitcoin Core can only sign messages for legacy (P2PKH) addresses, Knots can also sign for other address types, producing a BIP-322 "simple" signature automatically:
 
 ```bash
-bitcoin-cli signmessage "address" "message"
+bitcoin-cli signmessage "bc1q..." "message"
 ```
 
 ## verifymessage
 
 Enhanced to support multiple signature formats:
-- Standard Bitcoin signatures
-- BIP-137 format
-- Electrum format
+- Standard legacy Bitcoin signatures (P2PKH)
+- Legacy-style signatures with BIP-137 header bytes (covering P2SH-segwit and native segwit addresses)
+- BIP-322 signatures (both simple and full formats)
 
 ```bash
 bitcoin-cli verifymessage "address" "signature" "message"
@@ -68,23 +70,18 @@ bitcoin-cli verifymessage "address" "signature" "message"
 
 ## getpeerinfo
 
-Enhanced with additional fields:
+Additional per-peer fields:
+
+- `last_block_announcement`: the time this peer was first to announce a block
+- `misbehavior_score`: **deprecated** — always 0, or 100 if the peer is about to be disconnected; do not rely on it as a live metric
 
 ```bash
 bitcoin-cli getpeerinfo
 ```
 
-Additional fields:
-- `misbehaving_score`: Peer misbehavior score
-- `last_block_announcement`: Time of last block announcement
+## getaddressinfo
 
-## fundrawtransaction
-
-Enhanced with `min_conf` option:
-
-```bash
-bitcoin-cli fundrawtransaction "rawtx" '{"min_conf": 6}'
-```
+Includes a Knots-specific `use_txids` array listing the ids of wallet transactions which received with the address. See [New Commands](/patches/rpc/new-commands).
 
 ## See Also
 

--- a/docs/patches/rpc/new-commands.md
+++ b/docs/patches/rpc/new-commands.md
@@ -10,21 +10,40 @@ Bitcoin Knots includes several RPC commands not available in Bitcoin Core.
 
 ## Mempool Commands
 
-### listmempooltxs
+### listmempooltransactions
 
-List transactions in the mempool with filtering options:
+Returns all transactions in the mempool, with an `entry_sequence` value per entry so you can poll for new entries (an alternative to ZMQ notifications):
 
 ```bash
-bitcoin-cli listmempooltxs
+# All mempool transactions (txids + sequence numbers)
+bitcoin-cli listmempooltransactions
+
+# Only entries since a given mempool sequence, with full decoded transactions
+bitcoin-cli listmempooltransactions 12345 true
 ```
+
+Parameters: `start_sequence` (default 0 — all transactions) and `verbose` (default false).
+
+### maxmempool
+
+New in v29.3: change the memory allocated to the mempool at runtime, without restarting the node:
+
+```bash
+# Set the mempool allocation to 150 MB
+bitcoin-cli maxmempool 150
+```
+
+Takes a single `megabytes` argument. The current value is reported in the `maxmempool` field of `getmempoolinfo`.
 
 ### getmempoolinfo (Enhanced)
 
-Returns extended mempool information including fee histogram:
+Knots extends `getmempoolinfo` with an optional fee-histogram argument. Pass `true` for default fee-rate buckets, or an array of custom bucket boundaries:
 
 ```bash
-bitcoin-cli getmempoolinfo
+bitcoin-cli getmempoolinfo true
 ```
+
+The response then includes a `fee_histogram` object (not available in Bitcoin Core).
 
 ## Block Commands
 
@@ -58,11 +77,13 @@ bitcoin-cli getblockfileinfo 1234
 
 ### sweepprivkeys
 
-Import and sweep private keys:
+Sweep the funds controlled by one or more private keys into the loaded wallet. Takes a single options object (there is no destination parameter — funds go to a new address in your wallet) and returns the sweep transaction id:
 
 ```bash
-bitcoin-cli sweepprivkeys '["privkey1"]' "destination"
+bitcoin-cli -rpcwallet=mywallet sweepprivkeys '{"privkeys": ["<WIF key>"], "label": "swept"}'
 ```
+
+See [Sweep Private Keys](/patches/wallet/sweep-keys) for details.
 
 ### dumpmasterprivkey
 
@@ -114,7 +135,7 @@ Enhanced with transaction ID information:
 bitcoin-cli getaddressinfo "address"
 ```
 
-Includes `txids` field showing transactions involving the address.
+Includes a `use_txids` field listing the ids of wallet transactions which received with the address.
 
 ## See Also
 

--- a/docs/patches/wallet/codex32.md
+++ b/docs/patches/wallet/codex32.md
@@ -45,14 +45,14 @@ MS12NAMEA320ZYXWVUTSRQPNMLKJHGFEDCAXRPP870HKKQRM
 │││ │    │              Data + Checksum
 │││ │    └── Share index (A-Z, or S for secret)
 │││ └────── Identifier (4 characters)
-││└──────── Threshold (1-9 shares needed)
-│└───────── Version (always 1 for now)
+││└──────── Threshold (0 = no split, otherwise 2-9)
+│└───────── Bech32 separator (always 1)
 └────────── Human readable part (MS = "master seed")
 ```
 
 **Components:**
 - **MS**: Human-readable prefix (case-insensitive)
-- **1**: Version number
+- **1**: Bech32 separator
 - **2**: Threshold (2 shares needed to recover)
 - **NAME**: 4-character identifier for this backup set
 - **A**: Share index (A = first share, S = the secret itself)
@@ -82,46 +82,57 @@ Codex32 uses [Shamir's Secret Sharing](https://en.wikipedia.org/wiki/Shamir%27s_
 
 **Key properties:**
 - Split into up to **31 shares**
-- Threshold from **1 to 9** shares required
+- Threshold of **0** (no splitting) or **2 to 9** shares required (a threshold of 1 is invalid)
 - Below threshold: **zero information** about secret
 - Mathematical guarantee, not just obscurity
 
 ### Error Correction
 
 The 13-character checksum can:
-- **Detect** up to 8 errors anywhere in the string
+- **Detect** up to 8 character substitution errors anywhere in the string
 - **Correct** up to 4 character substitutions
-- **Handle** up to 15 consecutive erasures (unreadable characters)
 
 This means small transcription errors when copying by hand can be automatically fixed.
 
 ## Using Codex32 in Bitcoin Knots
 
-### Importing a Codex32 Seed
+Bitcoin Knots supports Codex32 through the **`seeds` argument of the `importdescriptors` RPC** (available since v25.0.knots20230823). There is no separate Codex32 RPC — you pass your codex32-encoded seed or shares alongside the descriptors they should satisfy.
+
+Each entry in `seeds` is a list of codex32 strings: either the single **S** (secret) share, or at least *threshold* shares from the same backup set. Knots recovers the seed, derives the BIP32 master key from it, and uses that key as private data for the descriptors being imported. The descriptors themselves reference the corresponding extended public key.
+
+### Importing with the Secret (S) Share
 
 ```bash
-# Import a single share (if threshold = 1) or the secret directly
-bitcoin-cli importcodex32 "MS10TESTSXXXXXXXXXXXXXXXXXXXXXXXXXX4NZVSHKZ"
+# Create an empty descriptor wallet to restore into
+bitcoin-cli createwallet "restored" false true
+
+# Import a descriptor, supplying the codex32 secret as its seed
+bitcoin-cli -rpcwallet=restored importdescriptors \
+  '[{"desc": "wpkh(<xpub>/0/*)#checksum", "timestamp": 0, "active": true, "range": [0, 999]}]' \
+  '[["ms10testsxxxxxxxxxxxxxxxxxxxxxxxxxx4nzvca9cmczlw"]]'
 ```
 
-### Importing Multiple Shares
+### Combining Multiple Shares
 
-For threshold > 1, you need to combine shares:
+For a split backup (threshold 2 or more), provide at least *threshold* shares from the same set:
 
 ```bash
-# Import with multiple shares
-bitcoin-cli importcodex32 '[
-  "MS12NAMEA320ZYXWVUTSRQPNMLKJHGFEDCAXRPP870HKKQRM",
-  "MS12NAMEB320ZYXWVUTSRQPNMLKJHGFEDCADH7HDLHPMS5X"
-]'
+bitcoin-cli -rpcwallet=restored importdescriptors \
+  '[{"desc": "tr(<xpub>/0/*)#checksum", "timestamp": 0, "active": true, "range": [0, 999]}]' \
+  '[[
+    "MS12NAMEA320ZYXWVUTSRQPNMLKJHGFEDCAXRPP870HKKQRM",
+    "MS12NAMECACDEFGHJKLMNPQRSTUVWXYZ023FTR2GDZMPY6PN"
+  ]]'
 ```
+
+Notes:
+- A single codex32 string must be the **S** share (the secret itself); anything else is rejected with "single share must be the S share".
+- Providing fewer shares than the threshold fails with a "did not have enough input shares" error.
+- Multiple seeds can be imported at once — `seeds` is an array of share lists, one per seed.
 
 ### Verifying a Share
 
-```bash
-# Check if a share is valid (checksum verification)
-bitcoin-cli validatecodex32 "MS12NAMEA320ZYXWVUTSRQPNMLKJHGFEDCAXRPP870HKKQRM"
-```
+Every codex32 string is checksum-validated during import: an invalid share is rejected with an `Invalid codex32 share` error before anything is imported. For verification without a computer, use the checksum worksheet from [secretcodex32.com](https://secretcodex32.com/).
 
 ## Creating Codex32 Backups
 
@@ -163,16 +174,7 @@ Codex32 includes printable tools for hand computation:
 
 ### Using External Tools
 
-For those comfortable with electronics during creation:
-
-```bash
-# Using seedtool (Blockchain Commons)
-seedtool --format codex32 --shares 3 --threshold 2
-
-# Using Python library
-pip install codex32
-python -c "from codex32 import generate; print(generate(threshold=2, shares=3))"
-```
+For those comfortable with electronics during creation, [BIP-93](https://github.com/bitcoin/bips/blob/master/bip-0093.mediawiki) links to reference implementations for generating and splitting codex32 seeds. The interactive tools at [secretcodex32.com](https://secretcodex32.com/) can also be used.
 
 ## Security Considerations
 
@@ -195,7 +197,7 @@ Never store all shares in one location. The whole point of splitting is geograph
 :::tip Threshold Selection
 - **Threshold 2 of 3**: Good balance of security and convenience
 - **Threshold 3 of 5**: Higher security for large holdings
-- **Threshold 1**: No splitting (just checksummed backup)
+- **Threshold 0**: No splitting (just a checksummed backup of the secret)
 :::
 
 **Storage recommendations:**
@@ -254,8 +256,11 @@ Codex32 supports standard BIP-32 seed lengths:
 ```
 1. Gather any 2 shares (A+B, A+C, or B+C)
 
-2. Use recovery wheel or:
-   bitcoin-cli importcodex32 '["MS12VAULTA...", "MS12VAULTB..."]'
+2. Use the recovery wheel by hand, or let Knots combine
+   the shares while importing your descriptors:
+   bitcoin-cli importdescriptors \
+     '[{"desc": "...", "timestamp": 0, "active": true}]' \
+     '[["MS12VAULTA...", "MS12VAULTB..."]]'
 
 3. Wallet is restored with full funds access
 ```
@@ -273,19 +278,12 @@ Codex32 uses polynomial interpolation over a finite field:
 ### Checksum Specification
 
 - **Generator polynomial**: Specifically chosen for Bech32 alphabet
-- **Error detection**: Guaranteed for up to 8 errors
-- **Error correction**: Can fix 4 substitutions automatically
-- **Erasure handling**: Up to 15 consecutive unreadable characters
+- **Error detection**: Guaranteed for up to 8 substitution errors
+- **Error correction**: Can fix up to 4 substitutions automatically
 
-## Wallet Support Status
+## Wallet Support
 
-| Wallet | Codex32 Support |
-|--------|-----------------|
-| **Bitcoin Knots** | Import supported |
-| Bitcoin Core | PR pending |
-| Blockstream Green | Planned |
-| Sparrow | Under consideration |
-| Liana | Planned |
+Bitcoin Knots supports importing codex32 seeds and shares via `importdescriptors` (see above). Support in other wallets varies — check your wallet's documentation, or see the reference implementations linked from [BIP-93](https://github.com/bitcoin/bips/blob/master/bip-0093.mediawiki) for standalone tooling.
 
 ## See Also
 

--- a/docs/patches/wallet/legacy-wallet.md
+++ b/docs/patches/wallet/legacy-wallet.md
@@ -10,13 +10,15 @@ Bitcoin Core v30 completely removed Berkeley DB legacy wallet support, forcing u
 
 ## Why This Matters
 
-| Feature | Core v30 | Knots v29.2 |
+| Feature | Core v30 | Knots v29.3 |
 |---------|----------|-------------|
 | Legacy wallet creation | **Removed** | Supported |
 | Berkeley DB wallets | **Removed** | Supported |
-| `dumpprivkey` RPC | Descriptor only | **Both types** |
-| `importprivkey` RPC | Descriptor only | **Both types** |
+| `dumpprivkey` RPC | **Removed** | Available (legacy wallets) |
+| `importprivkey` RPC | **Removed** | Available (legacy wallets) |
 | Direct key management | Limited | **Full** |
+
+(`dumpprivkey` and `importprivkey` only ever worked on legacy wallets — with legacy wallets removed in Core v30, these RPCs are simply gone there.)
 
 Many users need legacy wallets for:
 - **Older hardware wallets** with specific BIP32 paths
@@ -110,7 +112,7 @@ bitcoin-cli -rpcwallet=mylegacy migratewallet
 
 ## Descriptor Wallets (Default in v23+)
 
-Since Knots v23.0, new wallets default to descriptor format. Key differences:
+Since v23.0 — a default inherited from upstream Bitcoin Core 23 — new wallets default to descriptor format. Key differences:
 
 | Feature | Legacy | Descriptor |
 |---------|--------|------------|
@@ -132,7 +134,7 @@ bitcoin-cli createwallet "mydesc" false false "" false true
 |---------|-------------|
 | `dumpmasterprivkey` | Export HD master key (legacy) |
 | `sweepprivkeys` | Import and sweep in one step |
-| `importfromcoldcard` | Import Coldcard wallet |
+| `importfromcoldcard` | Import Coldcard wallet (a `bitcoin-wallet` tool command, not an RPC) |
 
 ## See Also
 

--- a/docs/patches/wallet/sweep-keys.md
+++ b/docs/patches/wallet/sweep-keys.md
@@ -6,7 +6,7 @@ description: Import and sweep funds from private keys in one atomic operation
 
 # Sweep Private Keys
 
-Bitcoin Knots includes the `sweepprivkeys` RPC command — a feature [proposed for Bitcoin Core](https://github.com/bitcoin/bitcoin/pull/9152) but never merged. It allows importing private keys and sweeping their funds in a single atomic operation.
+Bitcoin Knots includes the `sweepprivkeys` RPC command — a feature [proposed for Bitcoin Core](https://github.com/bitcoin/bitcoin/pull/9152) but never merged. It scans for funds controlled by the private keys you provide and moves them into your currently loaded wallet in a single operation.
 
 ## Why Sweep Instead of Import?
 
@@ -22,75 +22,102 @@ Sweeping is safer because:
 
 ## Usage
 
+`sweepprivkeys` takes a single **options object**. There is no destination or fee rate parameter — swept funds always go to a freshly generated address in the wallet the command is run against, and the fee is calculated automatically from your wallet's fee settings. The command returns the transaction id of the sweep.
+
 ### Basic Sweep
 
 ```bash
-bitcoin-cli sweepprivkeys '["5KJvsngHeMpm884wtkJNzQGaCErckhHJBGFsvd3VyK5qMZXj3hS"]' "bc1q..."
+bitcoin-cli -rpcwallet=mywallet sweepprivkeys '{"privkeys": ["5KJvsngHeMpm884wtkJNzQGaCErckhHJBGFsvd3VyK5qMZXj3hS"]}'
 ```
 
 ### Multiple Keys
 
 ```bash
-bitcoin-cli sweepprivkeys '["key1", "key2", "key3"]' "bc1qyouraddress..."
+bitcoin-cli -rpcwallet=mywallet sweepprivkeys '{"privkeys": ["key1", "key2", "key3"]}'
 ```
 
-### With Custom Fee Rate
+### With a Label
+
+The receiving address is added to your wallet's address book; you can label it:
 
 ```bash
-bitcoin-cli sweepprivkeys '["5KJvs..."]' "bc1q..." 10
+bitcoin-cli -rpcwallet=mywallet sweepprivkeys '{"privkeys": ["5KJvs..."], "label": "old paper wallet"}'
 ```
 
 ## Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `privkeys` | array | Yes | Array of WIF-encoded private keys |
-| `destination` | string | Yes | Address to receive swept funds |
-| `fee_rate` | number | No | Fee rate in sat/vB (default: automatic) |
+| `options` | object | Yes | Single options object (see fields below) |
+| `options.privkeys` | array | Yes | Array of WIF-encoded private keys |
+| `options.label` | string | No | Label for the received bitcoins |
+
+**Result:** the transaction id (hex string) of the sweep transaction.
+
+:::info Why no destination address?
+Sweeping and sending to an arbitrary address in a single action is intentionally unsupported — the Knots source notes it "isn't safe to sweep-and-send in a single action", since the send would be missing from your transaction history. Sweep into your wallet first, then send onward as a normal transaction.
+:::
 
 ## How It Works
 
-1. **UTXO Scan**: Scans the UTXO set for outputs spendable by the provided keys
-2. **Transaction Creation**: Creates a transaction spending all found UTXOs
-3. **Broadcast**: Sends funds to the destination address
-4. **Cleanup**: Keys are not persisted in the wallet
+1. **Address Reservation**: A new receiving address is reserved from your wallet's keypool
+2. **UTXO Scan**: The mempool and UTXO set are scanned for outputs spendable by the provided keys
+3. **Transaction Creation**: A transaction spending all found UTXOs is created and signed, deducting only the network fee
+4. **Broadcast**: Funds are sent to the new address in your wallet
+5. **Cleanup**: The provided keys are not persisted in the wallet
 
 ```
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│ Private Key │ --> │ UTXO Scan   │ --> │ New Address │
-│ (temporary) │     │ & Sweep TX  │     │ (yours)     │
-└─────────────┘     └─────────────┘     └─────────────┘
+┌─────────────┐     ┌─────────────┐     ┌──────────────┐
+│ Private Key │ --> │ UTXO Scan   │ --> │ New Address  │
+│ (temporary) │     │ & Sweep TX  │     │ (your wallet)│
+└─────────────┘     └─────────────┘     └──────────────┘
 ```
+
+### Supported Output Types
+
+For each key, Knots looks for P2PK and P2PKH outputs. Since **v29.3**, it also scans for segwit and taproot outputs of compressed keys:
+
+| Output type | Supported |
+|-------------|-----------|
+| P2PK (raw pubkey) | Yes |
+| P2PKH (legacy address) | Yes |
+| P2WPKH (native segwit) | Yes — v29.3+ (compressed keys) |
+| P2SH-P2WPKH (wrapped segwit) | Yes — v29.3+ (compressed keys) |
+| P2TR (taproot, key-path) | Yes — v29.3+ (compressed keys) |
+
+### GUI Support (v29.3+)
+
+Knots v29.3 adds a **"Sweep private key…"** dialog to the GUI, available from the **File** menu, so sweeps no longer require the command line.
 
 ## Use Cases
 
 ### Paper Wallet Redemption
 
 ```bash
-# Sweep a paper wallet to your HD wallet
+# Sweep a paper wallet into your HD wallet
 PAPER_KEY="5KJvsngHeMpm884wtkJNzQGaCErckhHJBGFsvd3VyK5qMZXj3hS"
-MY_ADDR=$(bitcoin-cli getnewaddress)
-bitcoin-cli sweepprivkeys "[\"$PAPER_KEY\"]" "$MY_ADDR"
+bitcoin-cli -rpcwallet=mywallet sweepprivkeys "{\"privkeys\": [\"$PAPER_KEY\"], \"label\": \"paper wallet\"}"
 ```
 
-### Merchant Payment Acceptance
+### Gift Card / Physical Bitcoin Redemption
 
-Merchants can accept payments via typed or scanned private keys:
+If someone hands you a private key (e.g., from a gift card or physical coin), sweep it into your own wallet before treating the funds as yours. Once swept, send the funds onward with a normal `sendtoaddress` if needed:
 
 ```bash
-# Customer provides private key (e.g., from gift card)
-bitcoin-cli sweepprivkeys '["customer_privkey"]' "merchant_address"
+bitcoin-cli -rpcwallet=mywallet sweepprivkeys '{"privkeys": ["gift_card_privkey"]}'
+# Then, once confirmed, optionally forward the funds:
+bitcoin-cli -rpcwallet=mywallet sendtoaddress "bc1q..." 0.001
 ```
 
 ### Consolidating Old Keys
 
 ```bash
-# Sweep multiple old keys to a single new address
-bitcoin-cli sweepprivkeys '[
+# Sweep multiple old keys into your wallet in one transaction
+bitcoin-cli -rpcwallet=mywallet sweepprivkeys '{"privkeys": [
   "5KJvsngHeMpm...",
   "5HueCGU8rMjx...",
   "5Kb8kLf9zgW..."
-]' "bc1q_consolidation_address"
+], "label": "consolidation"}'
 ```
 
 ## Comparison with Manual Process
@@ -120,7 +147,7 @@ With `sweepprivkeys`:
 
 ```bash
 # One command, key not persisted
-bitcoin-cli sweepprivkeys '["5KJvs..."]' "bc1q..."
+bitcoin-cli -rpcwallet=mywallet sweepprivkeys '{"privkeys": ["5KJvs..."]}'
 ```
 
 ## Security Considerations
@@ -129,24 +156,24 @@ bitcoin-cli sweepprivkeys '["5KJvs..."]' "bc1q..."
 Once you sweep a key, consider it compromised. Never send new funds to addresses derived from that key.
 :::
 
-:::tip Verify Destination
-Always double-check the destination address before sweeping. There's no undo.
+:::tip Check the Right Wallet
+The swept funds go to the wallet the command runs against. When multiple wallets are loaded, use `-rpcwallet=` to select the correct one.
 :::
 
 ## Error Handling
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "No UTXOs found" | Key has no funds or already swept | Verify key controls expected address |
-| "Invalid private key" | Wrong format or typo | Use WIF format (starts with 5, K, or L) |
-| "Insufficient fee" | Low fee rate during congestion | Increase fee_rate parameter |
+| "No value to sweep" | Key has no funds or already swept | Verify key controls expected outputs |
+| "Invalid private key encoding" | Wrong format or typo | Use WIF format (starts with 5, K, or L) |
+| "Swept value would be dust" | Funds too small to cover the fee | Wait for lower fees, or sweep together with other keys |
 
 ## Related Commands
 
 | Command | Description |
 |---------|-------------|
-| `importprivkey` | Import key (persists in wallet) |
-| `dumpprivkey` | Export key from wallet |
+| `importprivkey` | Import key (persists in wallet; legacy wallets only) |
+| `dumpprivkey` | Export key from wallet (legacy wallets only) |
 | `listunspent` | List UTXOs (manual approach) |
 
 ## See Also

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -8,6 +8,79 @@ description: Bitcoin Knots release history
 
 Release history for Bitcoin Knots.
 
+## Version 29.3.knots20260508
+
+**Released:** May 2026 (current release)
+
+Based on Bitcoin Core 29.3.
+
+### Highlights
+
+- **Opt-in BIP-110/RDTS support**: This build can enforce the Reduced Data Temporary Softfork, but only with explicit confirmation — via a GUI prompt at startup or `consensusrules=rdts` in `bitcoin.conf`. A build without RDTS support (29.3.knots20260507) is also available.
+- **RAM-aware `dbcache` default**: When `-dbcache` is not set explicitly, Knots now auto-selects a value between 100 MiB and 2 GiB based on system memory (#34641)
+- **`sweepprivkeys` extended**: now also finds segwit (p2wpkh) and taproot (p2tr) UTXOs, in addition to p2pk and p2pkh (knots#296)
+- **"Sweep private key" GUI dialog** added to the File menu (knots#297)
+- **Sub-dust fee penalty**: transactions creating sub-dust outputs have their effective fee reduced accordingly; enabled by default, disable with `subdustfeepenalty=0` (knots#272)
+- **Datacarrier filter hardening**: datacarrier policy options now match a newer spam variation ("opnet") designed to bypass the prior implementation (knots#292)
+- **Tor hidden-service PoW defenses** enabled for automatically created hidden services, when the Tor daemon supports them (#33414)
+- **`maxmempool` RPC** to adjust the mempool memory limit at runtime
+
+### Changes
+
+#### Consensus
+- knots#238: Reduced Data Temporary Softfork (RDTS), implemented as a modified BIP9 temporary deployment (opt-in)
+
+#### Policy
+- knots#272: Penalize effective fee for sub-dust outputs
+- knots#292: Add 'opnet' to datacarriersize matching
+
+#### P2P and Network
+- #33414: Enable PoW defenses for automatically created Tor hidden services
+- #35087: Limit torcontrol line size to prevent OOM
+- #35116 / #35117: Clean up SOCKS5 and I2P error logging
+
+#### GUI
+- knots#256: Prompt user after upgrading to RDTS-enabled version
+- knots#297: Add sweep private key dialog
+- knots#287: Warn when script threads exceed CPU cores
+- knots#288: Expand sync progress bar in status bar
+
+#### Wallet
+- #34870: Fix feebumper crash when combined bump fee is unavailable
+- #34959: Enforce BDB btree levels and overflow item sizes
+- knots#266: Validate external signer fingerprint is hex before shell command use
+- knots#267: Codex32: prevent out-of-bounds read on validation error
+
+#### RPC
+- knots#296: Add segwit and taproot support to sweepprivkeys
+- knots#294: Fix unsigned underflow in GetBlockFileInfo bounds check
+
+See the [official release notes](https://github.com/bitcoinknots/bitcoin/releases/tag/v29.3.knots20260508) for the full change log.
+
+---
+
+## Version 29.3.knots20260507
+
+**Released:** May 8, 2026
+
+Identical to 29.3.knots20260508, except it **does not support the BIP-110/RDTS network upgrade**. Provided for users who are not ready to adopt RDTS.
+
+---
+
+## Version 29.3.knots20260210
+
+**Released:** February 10, 2026
+
+Based on Bitcoin Core 29.3.
+
+### Highlights
+
+- Numerous wallet bug fixes, including some obscure scenarios that could delete the wallet (migration issues, backup path handling, and crashes when wallet directories lack write permissions)
+- P2P stability fixes, including a use-after-free in the v2-to-v1 reconnection logic
+- Qt updated to 5.15.18
+
+---
+
 ## Version 29.2.knots20251110
 
 **Released:** November 10, 2025
@@ -51,6 +124,22 @@ Thanks to all contributors including:
 - Antoine Poinsot
 - Luke Dashjr
 - And others
+
+---
+
+## Version 29.2.knots20251010
+
+**Released:** October 10, 2025
+
+Based on Bitcoin Core 29.2.
+
+### Highlights
+
+- Various bug fixes and a new Dockerfile (see `contrib/docker`)
+- Discontinued advertising the NODE_REPLACE_BY_FEE service bit
+- Tor control improvements, including ephemeral config files
+- Improved NAT-PMP/PCP logging and connection handling
+- Wallet migration fixes and improved macOS icon rendering
 
 ---
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -87,15 +87,21 @@ bitcoin-qt [options]
 ### GUI Options
 
 ```bash
-# Enable dark mode (fusion style)
+# Use a specific Qt widget style (generic Qt flag)
 bitcoin-qt -style=fusion
 
-# Minimize to tray on startup
+# Start minimized (minimizes to tray only if enabled in settings)
 bitcoin-qt -min
 
 # Reset GUI settings
 bitcoin-qt -resetguisettings
 ```
+
+:::note
+
+Knots dark mode is native and follows your system theme automatically — no flag needed. `-style=fusion` merely selects a Qt widget style.
+
+:::
 
 ## bitcoin-tx
 
@@ -132,16 +138,24 @@ bitcoin-wallet -wallet=new create
 # Get wallet info
 bitcoin-wallet -wallet=existing info
 
-# Dump wallet
-bitcoin-wallet -wallet=existing dump
+# Dump wallet records (requires -dumpfile)
+bitcoin-wallet -wallet=existing -dumpfile=/path/to/wallet.dump dump
 ```
 
-## Environment Variables
+## Pointing Tools at the Right Node
 
-| Variable | Description |
-|----------|-------------|
-| `BITCOIN_DATADIR` | Data directory |
-| `BITCOIN_CLI_ARGS` | Default CLI arguments |
+There are no environment variables for this — use command-line options instead:
+
+```bash
+# Use a non-default data directory
+bitcoin-cli -datadir=/path/to/data <command>
+
+# Use a specific config file
+bitcoind -conf=/path/to/bitcoin.conf
+
+# Use a specific RPC auth cookie
+bitcoin-cli -rpccookiefile=/path/to/.cookie <command>
+```
 
 ## See Also
 

--- a/docs/reference/configuration-options.md
+++ b/docs/reference/configuration-options.md
@@ -22,8 +22,9 @@ These options are unique to Bitcoin Knots or have different defaults than Bitcoi
 | `-datacarrierfullcount` | bool | 1 | Apply datacarriersize limit to all known datacarrier methods |
 | `-acceptnonstddatacarrier` | bool | 0 | Relay non-OP_RETURN datacarrier injection transactions |
 | `-permitbaredatacarrier` | bool | 0 | Relay transactions that only have data carrier outputs |
-| `-rejectparasites` | bool | 1 | **Refuse to relay CAT21 spam transactions** |
-| `-rejecttokens` | bool | 0 | Refuse to relay transactions involving non-bitcoin tokens |
+| `-rejectparasites` | bool | 1 | **Refuse to relay or mine parasitic overlay protocols** |
+| `-rejecttokens` | bool | 0 | Refuse to relay or mine transactions involving non-bitcoin tokens (Runes, OLGA-pattern data) |
+| `-subdustfeepenalty` | bool | 1 | Reduce effective fee by the dust threshold for each sub-dust output (v29.3+) |
 
 ### Script & Validation Policy
 
@@ -32,6 +33,7 @@ These options are unique to Bitcoin Knots or have different defaults than Bitcoi
 | `-acceptnonstdtxn` | bool | 0 | Relay and mine non-standard transactions |
 | `-permitbarepubkey` | bool | 0 | Relay transactions with bare pubkey outputs |
 | `-permitbaremultisig` | bool | 0 | Relay transactions with bare multisig outputs |
+| `-permitbareanchor` | bool | 1 | Relay transactions that only have ephemeral anchor outputs |
 | `-permitephemeral` | string | "anchor,-send,-dust" | Comma-separated ephemeral output options |
 | `-acceptunknownwitness` | bool | 1 | Relay transactions to unknown witness versions |
 | `-maxscriptsize` | int | 1650 | Maximum script size (including witness) in bytes |
@@ -74,6 +76,14 @@ These options are unique to Bitcoin Knots or have different defaults than Bitcoi
 | `-blockreservedweight` | int | 8000 | Reserved weight for coinbase |
 | `-maxtxlegacysigops` | int | 2500 | Maximum legacy sigops per transaction |
 
+### Consensus Rules (v29.3+)
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `-consensusrules=<rules>` | string | none | Enforce the specified consensus rules. Set to `rdts` to opt in to the BIP-110/RDTS softfork |
+
+RDTS enforcement is **opt-in**: v29.3.knots20260508 asks for explicit confirmation at GUI startup, or you can set `consensusrules=rdts` in `bitcoin.conf`. Without it, the node validates with the same consensus rules as Bitcoin Core.
+
 ### Core Policy Mode
 
 | Option | Type | Default | Description |
@@ -105,7 +115,7 @@ These options exist in both Core and Knots.
 | `-proxy` | string | - | SOCKS5 proxy (supports per-network syntax) |
 | `-onlynet` | string | all | Restrict to networks: ipv4, ipv6, onion, i2p, cjdns |
 | `-upnp` | bool | 0 | Enable UPnP port mapping |
-| `-natpmp` | bool | 1 | Enable NAT-PMP (default on in Knots v29+) |
+| `-natpmp` | bool | 1 | Use PCP or NAT-PMP to map the listening port (default on in Knots v29+) |
 
 ### RPC
 
@@ -122,7 +132,7 @@ These options exist in both Core and Knots.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `-dbcache` | int | 450 | Database cache size (MB) |
+| `-dbcache` | int | auto | Database cache size (MiB). Since v29.3, the default auto-scales with system RAM, between 100 MiB and 2 GiB; set explicitly to override |
 | `-par` | int | auto | Script verification threads |
 | `-maxmempool` | int | 300 | Maximum mempool size (MB) |
 | `-mempoolexpiry` | int | 336 | Mempool transaction expiry (hours) |
@@ -156,7 +166,7 @@ These options exist in both Core and Knots.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `-softwareexpiry` | bool | 1 | Enable expiry warnings (4-week warning, alerts at expiry) |
+| `-softwareexpiry` | timestamp | ~2 years after release | Stop working after this POSIX timestamp. The default is set roughly two years after the release, encouraging nodes to stay updated |
 
 ---
 

--- a/docs/reference/contributing.md
+++ b/docs/reference/contributing.md
@@ -31,14 +31,16 @@ Bitcoin Knots welcomes contributions from the community.
 
 ### Translation
 
-Help translate the interface (when Transifex access is restored).
+Translations follow the upstream Bitcoin Core translation process — see [doc/translation_process.md](https://github.com/bitcoinknots/bitcoin/blob/29.x-knots/doc/translation_process.md) in the repository. (Recent releases note that translation updates are currently disrupted by issues with the shared Bitcoin Transifex repository.)
 
 ## Getting Started
 
 ### 1. Fork the Repository
 
+Fork [bitcoinknots/bitcoin](https://github.com/bitcoinknots/bitcoin) on GitHub, then clone **your fork** and add the main repository as upstream:
+
 ```bash
-git clone https://github.com/bitcoinknots/bitcoin.git
+git clone https://github.com/YOUR_USERNAME/bitcoin.git
 cd bitcoin
 git remote add upstream https://github.com/bitcoinknots/bitcoin.git
 ```
@@ -54,11 +56,20 @@ git checkout -b my-feature
 
 Follow the coding style of the existing codebase.
 
-### 4. Test
+### 4. Build and Test
+
+Bitcoin Knots uses CMake:
 
 ```bash
-make check
-./test/functional/test_runner.py
+# Build
+cmake -B build
+cmake --build build -j$(nproc)
+
+# Run unit tests
+ctest --test-dir build
+
+# Run functional tests
+build/test/functional/test_runner.py
 ```
 
 ### 5. Commit

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -10,11 +10,11 @@ description: Frequently asked questions about Bitcoin Knots
 
 ### What is Bitcoin Knots?
 
-Bitcoin Knots is an enhanced derivative of Bitcoin Core, maintained by [Luke Dashjr](https://github.com/luke-jr) since 2011. It includes additional features, policy options, and improvements not available in Bitcoin Core while maintaining identical consensus rules.
+Bitcoin Knots is an enhanced derivative of Bitcoin Core, maintained by [Luke Dashjr](https://github.com/luke-jr) since 2011. It includes additional features, policy options, and improvements not available in Bitcoin Core while maintaining identical consensus rules by default (v29.3 adds one explicitly opt-in exception — see the [BIP-110/RDTS section](#bip-110--rdts) below).
 
 ### Is Bitcoin Knots safe to use?
 
-Yes. Bitcoin Knots follows identical consensus rules to Bitcoin Core, ensuring full network compatibility. The differences are in local policy (what your node relays) and features (GUI, wallet, RPC). Your node will validate the blockchain exactly the same as Core.
+Yes. By default, Bitcoin Knots follows identical consensus rules to Bitcoin Core, ensuring full network compatibility. The differences are in local policy (what your node relays) and features (GUI, wallet, RPC). Your node will validate the blockchain exactly the same as Core — unless you explicitly opt in to the RDTS softfork in v29.3+ (it is off by default and requires confirmation).
 
 ### Who maintains Bitcoin Knots?
 
@@ -30,7 +30,7 @@ The project was originally called "Bitcoin LJR" before being renamed.
 
 ### How popular is Bitcoin Knots?
 
-As of late 2025, Bitcoin Knots powers approximately **21% of all Bitcoin nodes** — a significant portion of the network. Adoption surged 850% in 2024-2025, largely driven by the OP_RETURN controversy and Core v30's removal of data limits.
+As of July 2026, Bitcoin Knots runs on roughly **23% of reachable Bitcoin nodes** ([bitdis.org](https://bitdis.org) measured 22.97% of 23,874 reachable nodes on July 2, 2026; [Coin Dance](https://coin.dance/nodes) showed 22.7%). The share peaked at about 25% in September 2025. Adoption surged in 2024-2025, largely driven by the OP_RETURN controversy and Core v30's removal of data limits. For current figures, check the live dashboards linked in [External Resources](/reference/resources).
 
 ---
 
@@ -55,7 +55,7 @@ The ~40,000 lines figure is roughly accurate when counting insertions (~36k). Th
 - ~70% is GUI, tests, and docs (zero consensus risk)
 - ~25% is wallet, RPC, policy (affects your node only)
 - Only ~4% (~1,400 lines) is consensus-adjacent
-- **0% changes consensus rules** — Knots validates identically to Core
+- **0% changes consensus rules** — Knots validates identically to Core (this analysis covers v29.2; v29.3 later added the opt-in, off-by-default RDTS softfork)
 
 **What's in the "consensus-adjacent" code?**
 - `bitcoinconsensus`: **Restored Core code** removed in v28 — already reviewed
@@ -68,27 +68,27 @@ See [Code Analysis](/architecture/code-analysis) for the full breakdown.
 
 | Feature | Bitcoin Core | Bitcoin Knots |
 |---------|--------------|---------------|
-| Consensus Rules | Standard | **Identical** |
+| Consensus Rules | Standard | **Identical by default** (v29.3 adds opt-in RDTS) |
 | Legacy Wallet | Removed (v30) | **Maintained** |
 | OP_RETURN Limit | Removed (v30) | **Configurable** |
 | Inscription Filtering | No | **Yes (default on)** |
-| Embedded Tor | No | **Yes** |
+| Automatic Tor launch | No | **Yes** (starts Tor for you if installed) |
 | Dark Mode | Partial | **Full support** |
 | UPnP | Removed | **Restored** |
 | Block Size Options | Removed | **Restored** |
 
 ### Will Knots fork Bitcoin?
 
-**No.** Knots follows the same consensus rules as Bitcoin Core. It will never create a network fork. The differences are purely in:
+**Not by default.** Out of the box, Knots follows the same consensus rules as Bitcoin Core. The differences are purely in:
 - What transactions your node **relays** (policy)
 - What features are **available** (GUI, RPC, wallet)
 - What **defaults** are used
 
-Your Knots node validates blocks identically to Core.
+By default, your Knots node validates blocks identically to Core. Since v29.3.knots20260508, there is one **explicitly opt-in** exception: the BIP-110/RDTS softfork, which is off by default, requires confirmation to enable, and is also offered as a separate build without it. If RDTS were to activate without broad hashrate support, enforcing nodes could diverge from non-enforcing nodes — see the [BIP-110/RDTS section](#bip-110--rdts) below.
 
 ### Can I run Knots and Core on the same network?
 
-Yes, they're fully compatible. Knots nodes communicate seamlessly with Core nodes. The network doesn't distinguish between them at the consensus level.
+Yes, they're fully compatible. Knots nodes communicate seamlessly with Core nodes. With default settings, the network doesn't distinguish between them at the consensus level.
 
 ### Does filtering affect the Bitcoin network?
 
@@ -98,6 +98,28 @@ No. Policy is local to your node. When you filter transactions:
 - Your node will still accept blocks containing them
 
 You're choosing what **your node** relays, not what the network allows.
+
+---
+
+## BIP-110 / RDTS
+
+### What is BIP-110 (RDTS)?
+
+The **Reduced Data Temporary Softfork** (RDTS) is a proposed temporary softfork that restricts data-carrying transactions at the consensus level. It is an official BIP, [BIP-110](https://github.com/bitcoin/bips/blob/master/bip-0110.mediawiki), and Knots implements it as a modified BIP9 temporary deployment that automatically expires after roughly one year of enforcement (~52,416 blocks).
+
+### Does Knots enforce RDTS?
+
+**Only if you explicitly opt in.** Knots v29.3.knots20260508 ships with RDTS support, but enforcement is **off by default**. To enable it, you must either confirm the GUI prompt shown at startup or add `consensusrules=rdts` to your `bitcoin.conf`. A build of the same version without RDTS support (29.3.knots20260507) is also available for users who don't want it.
+
+### How would RDTS activate?
+
+Via miner signaling on version bit 4: activation requires **55% of blocks (1,109 of 2,016) within a difficulty period** to signal support. The Knots deployment parameters also include a maximum activation height (block 965,664, roughly September 2026 per the implementation), after which the softfork activates regardless of signaling.
+
+As of late June 2026, signaling remains minimal — around **0.31% of hashrate**, mostly from the Ocean pool.
+
+### Is RDTS controversial?
+
+Yes. Critics — including Adam Back and Jameson Lopp — have warned that activating a softfork with minority hashrate support risks a **chain split**: nodes enforcing RDTS could end up following a different chain than the rest of the network. Supporters argue the upgrade fixes long-standing data-abuse vectors. If you enable RDTS, understand that you are opting in to enforcing rules the majority of the network may not enforce.
 
 ---
 
@@ -195,7 +217,7 @@ Potentially yes, but:
 ### What are "parasites" and "tokens"?
 
 - **Parasites** (`rejectparasites`): CAT21 spam transactions
-- **Tokens** (`rejecttokens`): Runes protocol transactions using OP_RETURN with OP_13
+- **Tokens** (`rejecttokens`): transactions involving non-bitcoin tokens — this covers Runes protocol transactions (OP_RETURN with OP_13) as well as OLGA-pattern data storage in P2WSH outputs
 
 Both are "data storage" uses of Bitcoin that some consider spam.
 
@@ -216,14 +238,18 @@ Yes. Both descriptor and legacy wallets are compatible.
 
 ### What is `sweepprivkeys`?
 
-A Knots command to import a private key and immediately send funds to a new address in one atomic operation. Safer than `importprivkey` because:
-- The imported key isn't stored in your wallet
-- Funds move to an address only you control
-- Original key exposure doesn't matter after sweep
+A Knots RPC that finds all funds controlled by a private key and sends them to a fresh address in your loaded wallet, in one operation. Safer than `importprivkey` because:
+- The swept key isn't stored in your wallet
+- Funds move to an address your wallet controls
+- Original key exposure doesn't matter after the sweep
+
+It takes a single options object (there is no destination argument — funds always go to a new address in the loaded wallet):
 
 ```bash
-bitcoin-cli sweepprivkeys '["5KJvs..."]' "bc1q_your_address"
+bitcoin-cli sweepprivkeys '{"privkeys": ["5KJvs..."], "label": "swept coins"}'
 ```
+
+Since v29.3, `sweepprivkeys` also finds segwit (p2wpkh) and taproot (p2tr) UTXOs in addition to p2pk/p2pkh, and the GUI has a matching "Sweep private key" dialog in the File menu.
 
 ### What is Codex32?
 
@@ -261,12 +287,9 @@ No. Knots doesn't modify the mining algorithm or proof-of-work. It only affects 
 
 ### How do I use Tor with Knots?
 
-**Simple way (embedded Tor):**
-```ini title="bitcoin.conf"
-torsubprocess=1
-```
+**Simple way (automatic):** if Tor is installed on your system, Knots will automatically launch it as a subprocess when appropriate — no configuration needed. (Knots doesn't bundle Tor itself; the command used can be overridden with the hidden `-torexecute=<command>` option, default `tor`.)
 
-**Manual way:**
+**Manual way (existing Tor daemon):**
 ```ini title="bitcoin.conf"
 proxy=127.0.0.1:9050
 listenonion=1

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -18,7 +18,7 @@ Useful tools for monitoring the Bitcoin network and Knots adoption.
 | [bitdis.org](https://bitdis.org) | Node distribution dashboard: Core vs Knots share, release adoption, and BIP-110 signaling |
 | [Bitbo Dashboard](https://bitbo.io) | Real-time Bitcoin stats, hash rate, fees, and network data |
 | [Clark Moody Dashboard](https://bitcoin.clarkmoody.com/dashboard/) | Real-time Bitcoin network metrics |
-| [The Bitcoin Portal](https://thebitcoinportal.com/) | Network statistics and node data |
+| [The Bitcoin Portal](https://thebitcoinportal.com/) | Bitcoin monetary health intelligence |
 
 :::note
 
@@ -31,10 +31,10 @@ Bitnodes (bitnodes.io), long the standard node explorer, went offline when its d
 On BTC Nodes, you can search for specific Knots versions by user agent:
 
 ```
-/Satoshi:29.2.0/Knots:20251110/
+/Satoshi:29.3.0/Knots:20260508/
 ```
 
-This shows all nodes running Knots 29.2.0 (November 2025 release).
+This shows all nodes running Knots 29.3.knots20260508 (May 2026 release).
 
 ### Searching by Service Flags
 
@@ -48,12 +48,12 @@ On BTC Nodes, you can search by service flags to find nodes signaling specific c
 
 ## Current Adoption
 
-As of early 2025, based on coin.dance data:
+As of July 2, 2026:
 
-- **Bitcoin Core**: ~18,600 nodes (78%)
-- **Bitcoin Knots**: ~5,100+ nodes (21%+)
+- [bitdis.org](https://bitdis.org) measured **22.97%** of 23,874 reachable nodes running Bitcoin Knots
+- [Coin Dance](https://coin.dance/nodes) showed a similar **22.7%** share
 
-Knots adoption increased significantly following the OP_RETURN controversy in mid-2025.
+The Knots share peaked at roughly 25% in September 2025, after adoption surged following the OP_RETURN controversy in mid-2025. These figures date quickly — check the live dashboards above for current numbers.
 
 ## Official Resources
 

--- a/docs/reference/rpc.md
+++ b/docs/reference/rpc.md
@@ -25,7 +25,8 @@ Bitcoin Knots includes all Bitcoin Core RPC commands plus additional Knots-speci
 |---------|-------------|
 | `getmempoolinfo` | Mempool statistics (enhanced in Knots) |
 | `getrawmempool` | List mempool transactions |
-| `listmempooltxs` | List mempool txs (Knots) |
+| `listmempooltransactions` | List mempool txs with sequence numbers, for polling-based sync (Knots) |
+| `maxmempool` | Set the mempool memory limit at runtime (Knots, v29.3+) |
 | `getmempoolentry` | Mempool entry details |
 
 ## Network
@@ -47,7 +48,7 @@ Bitcoin Knots includes all Bitcoin Core RPC commands plus additional Knots-speci
 | `getnewaddress` | Generate address |
 | `getbalance` | Wallet balance |
 | `sendtoaddress` | Send bitcoin |
-| `sweepprivkeys` | Sweep private keys (Knots) |
+| `sweepprivkeys` | Sweep private keys to a fresh wallet address (Knots; v29.3 adds p2wpkh/p2tr support) |
 | `dumpmasterprivkey` | Dump master key (Knots) |
 
 ## Mining

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -56,7 +56,7 @@ const config: Config = {
       {property: 'og:type', content: 'website'},
       {property: 'og:site_name', content: 'Study Knots'},
       {property: 'og:title', content: 'Study Knots - Learn Bitcoin Knots'},
-      {property: 'og:description', content: 'The comprehensive guide to Bitcoin Knots. Understand the enhanced Bitcoin Core derivative powering 21% of the network.'},
+      {property: 'og:description', content: 'The comprehensive guide to Bitcoin Knots. Understand the enhanced Bitcoin Core derivative powering nearly a quarter of the network.'},
       {property: 'og:image', content: 'https://studyknots.com/img/studyknots-social.png'},
       {property: 'og:image:width', content: '1200'},
       {property: 'og:image:height', content: '630'},
@@ -76,8 +76,8 @@ const config: Config = {
     },
 
     announcementBar: {
-      id: 'latest_release',
-      content: 'Bitcoin Knots 29.2 is now available! <a href="https://bitcoinknots.org/">Download from bitcoinknots.org</a>',
+      id: 'announcement_29_3',
+      content: 'Bitcoin Knots 29.3 (v29.3.knots20260508) is now available! <a href="https://bitcoinknots.org/">Download from bitcoinknots.org</a>',
       backgroundColor: '#4A90A4',
       textColor: '#fff',
       isCloseable: true,
@@ -162,8 +162,7 @@ const config: Config = {
         {
           title: 'Community',
           items: [
-            {label: 'Discord', href: 'https://discord.gg/bitcoin'},
-            {label: 'Telegram', href: 'https://t.me/bitcoinknots'},
+            {label: 'GitHub Issues', href: 'https://github.com/bitcoinknots/bitcoin/issues'},
             {label: 'Contributing', to: '/reference/contributing'},
           ],
         },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -45,8 +45,8 @@ function ControversyBanner() {
           <div className={styles.controversyText}>
             <Heading as="h2">The OP_RETURN Controversy</Heading>
             <p>
-              Bitcoin Core v30 removed OP_RETURN limits. Nick Szabo broke 5 years of silence to warn about it.
-              Learn why 21% of nodes switched to Knots.
+              Bitcoin Core v30 dropped OP_RETURN limits (unchanged through v31). Nick Szabo broke 5 years of silence to warn about it.
+              Learn why roughly a quarter of reachable nodes switched to Knots.
             </p>
           </div>
           <div className={styles.controversyButtons}>
@@ -58,7 +58,7 @@ function ControversyBanner() {
             <Link
               className="button button--secondary button--lg"
               to="/architecture/code-analysis">
-              Debunking the FUD
+              Read the Code Analysis
             </Link>
           </div>
         </div>
@@ -73,20 +73,20 @@ function StatsSection() {
       <div className="container">
         <div className="stats-container">
           <div className="stat-item">
-            <span className="stat-number">21%</span>
-            <span className="stat-label">Of All Nodes</span>
+            <span className="stat-number">~23%</span>
+            <span className="stat-label">Of All Nodes (July 2026)</span>
           </div>
           <div className="stat-item">
             <span className="stat-number">14+</span>
             <span className="stat-label">Years Active</span>
           </div>
           <div className="stat-item">
-            <span className="stat-number">v29.2</span>
+            <span className="stat-number">v29.3</span>
             <span className="stat-label">Current Release</span>
           </div>
           <div className="stat-item">
-            <span className="stat-number">100%</span>
-            <span className="stat-label">Consensus Compatible</span>
+            <span className="stat-number">Consensus</span>
+            <span className="stat-label">Compatible by Default</span>
           </div>
         </div>
       </div>
@@ -152,7 +152,7 @@ function HomepageFeatures() {
         <div className="text--center margin-bottom--xl">
           <Heading as="h2">What Makes Knots Different</Heading>
           <p className={styles.sectionSubtitle}>
-            Same consensus rules as Bitcoin Core. More features for power users.
+            Same consensus rules as Bitcoin Core by default. More features for power users.
           </p>
         </div>
         <div className="row">
@@ -188,11 +188,11 @@ function ComparisonSection() {
               <tr>
                 <td>Consensus Rules</td>
                 <td>Standard</td>
-                <td>Identical</td>
+                <td>Identical by default (RDTS opt-in)</td>
               </tr>
               <tr>
                 <td>Legacy Wallet</td>
-                <td>Deprecated</td>
+                <td>Removed (v30)</td>
                 <td>Maintained</td>
               </tr>
               <tr>

--- a/static/img/version-numbering-dark.svg
+++ b/static/img/version-numbering-dark.svg
@@ -39,9 +39,9 @@
   <!-- Dot -->
   <text x="130" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="20" font-weight="700" fill="#8892a0" text-anchor="middle">.</text>
 
-  <!-- Minor version: 2 -->
+  <!-- Minor version: 3 -->
   <rect x="145" y="42" width="36" height="36" rx="6" fill="url(#minorGradDark)"/>
-  <text x="163" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="20" font-weight="700" fill="#ffffff" text-anchor="middle">2</text>
+  <text x="163" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="20" font-weight="700" fill="#ffffff" text-anchor="middle">3</text>
 
   <!-- Dot -->
   <text x="195" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="20" font-weight="700" fill="#8892a0" text-anchor="middle">.</text>
@@ -50,9 +50,9 @@
   <rect x="210" y="42" width="80" height="36" rx="6" fill="url(#knotsGradDark)"/>
   <text x="250" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="18" font-weight="600" fill="#ffffff" text-anchor="middle">knots</text>
 
-  <!-- Date: 20251110 -->
+  <!-- Date: 20260508 -->
   <rect x="300" y="42" width="130" height="36" rx="6" fill="url(#dateGradDark)"/>
-  <text x="365" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="18" font-weight="600" fill="#ffffff" text-anchor="middle">20251110</text>
+  <text x="365" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="18" font-weight="600" fill="#ffffff" text-anchor="middle">20260508</text>
 
   <!-- Connector lines -->
   <line x1="95" y1="78" x2="95" y2="110" stroke="#4A90A4" stroke-width="2" stroke-dasharray="4,2"/>

--- a/static/img/version-numbering.svg
+++ b/static/img/version-numbering.svg
@@ -39,9 +39,9 @@
   <!-- Dot -->
   <text x="130" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="20" font-weight="700" fill="#6c757d" text-anchor="middle">.</text>
 
-  <!-- Minor version: 2 -->
+  <!-- Minor version: 3 -->
   <rect x="145" y="42" width="36" height="36" rx="6" fill="url(#minorGrad)"/>
-  <text x="163" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="20" font-weight="700" fill="#ffffff" text-anchor="middle">2</text>
+  <text x="163" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="20" font-weight="700" fill="#ffffff" text-anchor="middle">3</text>
 
   <!-- Dot -->
   <text x="195" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="20" font-weight="700" fill="#6c757d" text-anchor="middle">.</text>
@@ -50,9 +50,9 @@
   <rect x="210" y="42" width="80" height="36" rx="6" fill="url(#knotsGrad)"/>
   <text x="250" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="18" font-weight="600" fill="#ffffff" text-anchor="middle">knots</text>
 
-  <!-- Date: 20251110 -->
+  <!-- Date: 20260508 -->
   <rect x="300" y="42" width="130" height="36" rx="6" fill="url(#dateGrad)"/>
-  <text x="365" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="18" font-weight="600" fill="#ffffff" text-anchor="middle">20251110</text>
+  <text x="365" y="67" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="18" font-weight="600" fill="#ffffff" text-anchor="middle">20260508</text>
 
   <!-- Connector lines -->
   <line x1="95" y1="78" x2="95" y2="110" stroke="#4A90A4" stroke-width="2" stroke-dasharray="4,2"/>


### PR DESCRIPTION
Full review and update of all ~40 pages against the Bitcoin Knots v29.3.knots20260508 source tree and current (July 2026) external facts. 42 files changed across 9 commits, ordered by severity.

## Critical fixes

- **Installation guide had a GPG fingerprint that doesn't correspond to any real key.** Now points at the official `bitcoinknots/guix.sigs` builder-keys with Luke Dashjr's two verified fingerprints, and the expected `gpg` output reflects his ed25519 keys.
- **Removed invented options/RPCs** that appeared across many pages: `torsubprocess` (real mechanism: automatic Tor subprocess launch via hidden `-torexecute`), `listmempooltxs` (real: `listmempooltransactions`), `importcodex32`/`validatecodex32` (real: `importdescriptors` `seeds` argument), `BITCOIN_DATADIR`/`BITCOIN_CLI_ARGS` env vars, `bitcoin-cli -testconfig`, a `loadwallet` salvage parameter, and a `sweepprivkeys` destination/fee_rate signature that doesn't exist.
- **Fixed misconfiguring examples**: fee-rate options (`dustrelayfee`, `minrelaytxfee`, `incrementalrelayfee`) shown in satoshis instead of BTC/kvB, `dustdynamic=1` (invalid syntax), `bytespersigopstrict=1` (it's a byte count, default 20), `mempoolfullrbf` 0/1/2 (it's boolean; `mempoolreplacement` is the three-way control), and `maxscriptsize=10000` presented as tightening (default is 1650).
- Fixed PR #32406 attribution (authored by Gregory Sanders, merged by Gloria Zhao).

## Brought up to date (v29.3 / July 2026)

- Current release is now v29.3.knots20260508 everywhere (announcement bar, homepage tile, version-numbering SVGs, installation, changelog — which gained four missing releases).
- **BIP-110/RDTS**: the bip-110 page was frozen in January 2026. Now reflects that Knots 29.3 ships RDTS opt-in (`consensusrules=rdts`), signaling is live since March at ~0.31% of hashrate, mandatory signaling hits at blocks 961,632–963,647 (~early August), activation at 965,664 (~Sept 1), expiry corrected to height 1,018,080 per the official BIP, plus the Back/Lopp chain-split warnings. New coverage added to the FAQ, configuration guide, mining guide, and patches overview.
- All unqualified "identical consensus rules" claims are now scoped to "identical by default", with pinned-analysis banners on the architecture deep-dives.
- New 29.3 features documented on their owning pages: sweepprivkeys segwit/taproot + GUI dialog, `subdustfeepenalty`, `datacarrierfullcount`/bypass matching, Tor onion PoW defense, dbcache auto-scaling, `maxmempool` RPC.
- Core comparisons updated for v30/v31 (OP_RETURN limit removal, legacy wallet removal, Qt6).
- Build docs (architecture/build-system, creating-a-fork, contributing) rewritten from Autotools to CMake — the previous instructions could not work on the v29+ tree.
- Node-share stats date-stamped to July 2026 (~23%, after the ~25% Sept 2025 peak) with pointers to live dashboards; removed footer links to unaffiliated Discord/Telegram communities.

## Verification

- Every option name, default, and RPC signature was grepped in the v29.3.knots20260508 source before being written.
- `npm run build` passes with no broken-link warnings; sitewide grep confirms no fabricated identifiers remain.