### PR TITLE
Add BIP-110/RDTS integration page; correct enforcement semantics

### DIFF
--- a/docs/architecture/code-analysis.md
+++ b/docs/architecture/code-analysis.md
@@ -9,7 +9,7 @@ description: Objective analysis of Bitcoin Knots code differences from Core
 This page provides an objective, data-driven analysis of the code differences between Bitcoin Knots and Bitcoin Core. All numbers are verifiable by running `git diff` between the respective tags.
 
 :::info Analysis pinned to v29.2 vs Core 29.0
-The numbers on this page compare **Bitcoin Knots v29.2.knots20251110** against **Bitcoin Core v29.0**. The current release, **v29.3.knots20260508** (May 2026, based on Core 29.3), additionally ships the opt-in BIP-110 (RDTS) consensus ruleset (`consensusrules=rdts`, disabled by default), which is outside the scope of this analysis.
+The numbers on this page compare **Bitcoin Knots v29.2.knots20251110** against **Bitcoin Core v29.0**. The current release, **v29.3.knots20260508** (May 2026, based on Core 29.3), additionally ships the BIP-110 (RDTS) consensus ruleset — enforced by the standard build on its activation schedule, with a non-enforcing build also published — which is outside the scope of this analysis. See [BIP-110 / RDTS Integration](/patches/consensus/bip110).
 :::
 
 ## The "40,000 Lines" Claim
@@ -149,7 +149,7 @@ Primarily:
 | **Medium** | ~1,400 | ~4% | Consensus-adjacent but mostly policy/restored code |
 | **Remaining** | ~5,000 | ~14% | Misc (translations, contrib scripts, etc.) |
 
-**Consensus rule changes in the analyzed v29.2 release: 0%** — v29.2 follows identical consensus rules to Core, and later releases do the same in their default configuration. (Since v29.3, an explicitly opt-in RDTS ruleset exists — off by default.)
+**Consensus rule changes in the analyzed v29.2 release: 0%** — v29.2 follows identical consensus rules to Core. (v29.3 later added the RDTS soft-fork deployment, a deliberate consensus feature outside this analysis — see [BIP-110 / RDTS Integration](/patches/consensus/bip110).)
 
 ## Key Insight: Policy ≠ Consensus
 
@@ -218,7 +218,7 @@ The ~40,000 lines figure is roughly accurate. What matters is understanding that
 1. **~70% is GUI/tests/docs** — cannot affect consensus
 2. **~12% is wallet/RPC/policy** — affects your node only
 3. **~4% is consensus-adjacent** — mostly policy hooks and restored Core code
-4. **0% changes consensus rules in the analyzed v29.2 / default configuration** — Knots validates identically to Core unless you explicitly opt in to the v29.3+ RDTS ruleset
+4. **0% changes consensus rules in the analyzed v29.2 release** — Knots validated identically to Core; the deliberate RDTS soft-fork deployment came later, in v29.3
 
 The question isn't whether to trust 40,000 lines blindly. It's whether you trust:
 - A 14-year Bitcoin contributor

--- a/docs/architecture/code-review.md
+++ b/docs/architecture/code-review.md
@@ -7,7 +7,7 @@ description: Independent technical review of Bitcoin Knots consensus-adjacent co
 # Code Review Report
 
 :::caution Review pinned to v29.2
-This review covers **Bitcoin Knots v29.2.knots20251110**. The current release, **v29.3.knots20260508** (May 2026), additionally ships the opt-in BIP-110 (RDTS) consensus rules (`consensusrules=rdts`, disabled by default). Those rules are outside the scope of this review.
+This review covers **Bitcoin Knots v29.2.knots20251110**. The current release, **v29.3.knots20260508** (May 2026), additionally ships the BIP-110 (RDTS) consensus rules — enforced by the standard build on its activation schedule, with a non-enforcing build also published. Those rules are outside the scope of this review; see [BIP-110 / RDTS Integration](/patches/consensus/bip110).
 :::
 
 **Subject:** Bitcoin Knots v29.2.knots20251110 consensus-adjacent code
@@ -28,7 +28,7 @@ This review was conducted using AI-assisted static code analysis. It is not a fo
 | `consensus/` | 3 | +94 | **None** |
 | `script/bitcoinconsensus.*` | 2 | +252 | **None** (restored Core code) |
 
-**Conclusion:** No consensus rule changes were identified in v29.2.knots20251110, the release under review (and none apply in later releases' default configuration; v29.3's opt-in RDTS rules are outside this review's scope). All modifications are either:
+**Conclusion:** No consensus rule changes were identified in v29.2.knots20251110, the release under review. (v29.3's deliberate RDTS soft-fork deployment is outside this review's scope.) All modifications are either:
 1. Policy options (configurable relay behavior)
 2. Performance optimizations
 3. Restored Bitcoin Core code
@@ -369,7 +369,7 @@ After systematic review of all consensus-adjacent code in Bitcoin Knots v29.2, *
 2. **Performance optimizations** — Same results, faster computation
 3. **Restored Core code** — Previously reviewed code brought back for compatibility
 
-The claim that Knots contains "dangerous consensus changes" is **not supported by examination of the v29.2 code**. Knots v29.2 validates blocks identically to Bitcoin Core, and later releases do the same in their default configuration — the opt-in RDTS ruleset added in v29.3 only takes effect if the operator explicitly sets `consensusrules=rdts`, and would need a separate review.
+The claim that Knots contains "dangerous consensus changes" is **not supported by examination of the v29.2 code**. Knots v29.2 validates blocks identically to Bitcoin Core. The RDTS soft-fork deployment added in v29.3 is a deliberate, documented consensus feature — not a hidden change — and would need a separate review; see [BIP-110 / RDTS Integration](/patches/consensus/bip110).
 
 ---
 

--- a/docs/architecture/consensus-adjacent-code.md
+++ b/docs/architecture/consensus-adjacent-code.md
@@ -9,7 +9,7 @@ description: Detailed examination of Bitcoin Knots changes near consensus-critic
 This page provides a detailed examination of the ~4% of Bitcoin Knots code changes that touch files near consensus-critical areas. While these files are "consensus-adjacent," the changes examined here do not alter Bitcoin's consensus rules.
 
 :::caution Analysis pinned to v29.2
-This page examines **Bitcoin Knots v29.2.knots20251110** against **Bitcoin Core v29.0**. The current release, **v29.3.knots20260508** (May 2026), additionally ships the opt-in BIP-110 (RDTS) consensus ruleset (`consensusrules=rdts`, disabled by default), which is outside the scope of this page. In its default configuration, v29.3 validates identically to Core.
+This page examines **Bitcoin Knots v29.2.knots20251110** against **Bitcoin Core v29.0**. The current release, **v29.3.knots20260508** (May 2026), additionally ships the BIP-110 (RDTS) consensus ruleset — enforced by the standard build on its activation schedule (~September 2026), with a non-enforcing build also published — which is outside the scope of this page. Until RDTS activates, v29.3 validates identically to Core. See [BIP-110 / RDTS Integration](/patches/consensus/bip110).
 :::
 
 :::info Why This Matters
@@ -306,7 +306,7 @@ When evaluating consensus-adjacent code, ask:
 
 1. **Does it change validation rules?** → No (in the v29.2 code examined here)
 2. **Does it change consensus parameters?** → No
-3. **Could it cause a network fork?** → No — not unless you explicitly opt in to the v29.3+ RDTS ruleset with `consensusrules=rdts`, which is off by default and outside this page's scope
+3. **Could it cause a network fork?** → Not the code examined here. The separate question is the v29.3+ RDTS ruleset, which the standard build enforces on its activation schedule and which is outside this page's scope — see [BIP-110 / RDTS Integration](/patches/consensus/bip110)
 4. **Is it configurable/optional?** → Yes (mostly)
 5. **Was it reviewed?** → Yes (Core PRs, post-merge review)
 
@@ -358,7 +358,7 @@ The ~1,400 lines of consensus-adjacent code in Knots v29.2:
 3. **Include restored Core code** — Already reviewed, just restored
 4. **Are independently verifiable** — Commands provided above
 
-The claim that Knots has "dangerous consensus changes" is not supported by examination of the v29.2 code. The consensus-adjacent code adds policy flexibility while leaving actual consensus validation untouched. (The opt-in RDTS consensus ruleset added in v29.3 is a separate, explicitly-enabled feature not covered by this analysis.)
+The claim that Knots has "dangerous consensus changes" is not supported by examination of the v29.2 code. The consensus-adjacent code adds policy flexibility while leaving actual consensus validation untouched. (The RDTS consensus ruleset added in v29.3 is a separate, deliberate soft-fork deployment not covered by this analysis.)
 
 ## See Also
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -27,7 +27,7 @@ Bitcoin Knots (patches applied)
 
 ### Consensus Engine
 
-The consensus engine validates blocks and transactions according to Bitcoin's rules. **This is identical to Bitcoin Core by default** - in its default configuration, Knots makes no consensus changes. Since v29.3.knots20260508, Knots also ships an explicitly opt-in BIP-110 (RDTS) consensus ruleset (`consensusrules=rdts`), which is disabled by default.
+The consensus engine validates blocks and transactions according to Bitcoin's rules. **This is identical to Bitcoin Core today.** The one scheduled exception: since v29.3.knots20260508, the standard Knots build includes the BIP-110 (RDTS) consensus ruleset and will enforce it when it activates (~September 2026); a non-enforcing build is also published. See [BIP-110 / RDTS Integration](/patches/consensus/bip110).
 
 Key files:
 - `src/consensus/` - Consensus rules

--- a/docs/getting-started/differences-from-core.md
+++ b/docs/getting-started/differences-from-core.md
@@ -11,7 +11,7 @@ Bitcoin Knots includes numerous enhancements over Bitcoin Core. This page summar
 ## Consensus
 
 :::tip Important
-Bitcoin Knots follows **identical consensus rules** to Bitcoin Core **by default**. Your node will validate blocks exactly the same way. The one exception is the explicitly opt-in [BIP-110/RDTS soft fork](/guides/bip-110) added in v29.3 — see below.
+Bitcoin Knots follows **identical consensus rules** to Bitcoin Core. Your node validates blocks exactly the same way — until the [BIP-110/RDTS soft fork](/guides/bip-110) shipped in v29.3 activates (scheduled for ~September 2026), and only in the RDTS-enforcing build. See below.
 :::
 
 The differences are in:
@@ -20,16 +20,16 @@ The differences are in:
 - Additional features and RPC commands
 - User interface improvements
 
-### Consensus (opt-in)
+### Consensus (BIP-110 / RDTS)
 
-Since v29.3, Knots ships optional enforcement of the BIP-110 ReducedData Temporary Softfork (RDTS). It is **off by default** — you must explicitly opt in via configuration (or the GUI prompt):
+Since v29.3, the standard Bitcoin Knots build (v29.3.knots20260508) includes the BIP-110 Reduced Data Temporary Softfork (RDTS) and will enforce it on its deployment schedule. The build asks for your explicit confirmation — via a GUI prompt at startup, or in `bitcoin.conf`:
 
 ```ini title="bitcoin.conf"
-# Opt in to BIP-110/RDTS enforcement (Knots 29.3+, off by default)
+# Confirm the BIP-110/RDTS upgrade (Knots 29.3+); bitcoind warns hourly until set
 consensusrules=rdts
 ```
 
-Without this setting, Knots validates blocks identically to Bitcoin Core. See the [BIP-110 guide](/guides/bip-110) for details.
+Note that this setting records confirmation — it does not toggle enforcement. Users who don't want RDTS enforcement at all should run the parallel non-RDTS build (v29.3.knots20260507). See [BIP-110 / RDTS Integration](/patches/consensus/bip110) for the full mechanics and the [BIP-110 guide](/guides/bip-110) for background.
 
 ## Policy Differences
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,8 +14,8 @@ This guide covers downloading and installing Bitcoin Knots on various platforms.
 **Release Date:** May 8, 2026
 **Based on:** Bitcoin Core 29.3
 
-:::info RDTS opt-in
-v29.3.knots20260508 is the first release to ship the [BIP-110/RDTS soft fork](/guides/bip-110) — strictly **opt-in** (GUI confirmation or `consensusrules=rdts`; disabled by default). A parallel build without RDTS support, v29.3.knots20260507, is also available for users who prefer a client that cannot enforce it at all.
+:::info Two builds: with and without RDTS
+v29.3.knots20260508 is the first release to ship the [BIP-110/RDTS soft fork](/guides/bip-110). This build enforces RDTS on its deployment schedule and asks for explicit confirmation (GUI prompt, or `consensusrules=rdts` in bitcoin.conf). A parallel build without RDTS enforcement, v29.3.knots20260507, is available for users who prefer a client that cannot enforce it. See [BIP-110 / RDTS Integration](/patches/consensus/bip110) before choosing.
 :::
 
 ## Download
@@ -250,7 +250,7 @@ Running on unsupported systems is not recommended.
 
 | Version | Date | Notes |
 |---------|------|-------|
-| v29.3.knots20260508 | May 8, 2026 | Opt-in BIP-110/RDTS, dbcache auto-scaling, sweepprivkeys segwit/taproot + GUI dialog |
+| v29.3.knots20260508 | May 8, 2026 | BIP-110/RDTS (confirmation required), dbcache auto-scaling, sweepprivkeys segwit/taproot + GUI dialog |
 | v29.3.knots20260507 | May 8, 2026 | Same as above, without RDTS support |
 | v29.3.knots20260210 | Feb 10, 2026 | Wallet bug fixes, P2P use-after-free fixes |
 | v29.2.knots20251110 | Nov 10, 2025 | CVE-2025-46598 fix, datacarriersize default increased |

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -22,7 +22,7 @@ The name "Knots" has a dual meaning — it both references the merging/tying tog
 - **2023**: Luke Dashjr co-founded Ocean mining pool (which runs Knots)
 - **2025**: Adoption surged 638% as debates over OP_RETURN limits intensified
 - **November 2025**: Release v29.2.knots20251110
-- **May 2026**: Current release v29.3.knots20260508 — the first release to ship the opt-in BIP-110/RDTS soft fork
+- **May 2026**: Current release v29.3.knots20260508 — the first release to ship the BIP-110/RDTS soft fork (confirmation required; a non-RDTS build is also published)
 
 As of mid-2026, Bitcoin Knots powers roughly 23% of all reachable Bitcoin nodes (after peaking near 25% in late 2025) — a significant share of the network's infrastructure.
 
@@ -38,7 +38,7 @@ Bitcoin Knots follows the same consensus rules as Bitcoin Core — your node wil
 - **Conservative Defaults**: Knots defaults to filtering certain transaction types that Core allows
 
 :::info Consensus Compatibility
-Bitcoin Knots follows identical consensus rules to Bitcoin Core by default. Running Knots does not affect your node's ability to validate the blockchain correctly. The one exception is the explicitly opt-in [BIP-110/RDTS soft fork](/guides/bip-110) introduced in v29.3 — it is off unless you enable it. Otherwise the differences are purely in local policy and features.
+Bitcoin Knots follows identical consensus rules to Bitcoin Core. Running Knots does not affect your node's ability to validate the blockchain correctly. The one exception is the [BIP-110/RDTS soft fork](/guides/bip-110) introduced in v29.3: the standard build will enforce it on its activation schedule (~September 2026) after asking for your confirmation, and a non-enforcing build is also published — see [BIP-110 / RDTS Integration](/patches/consensus/bip110). Otherwise the differences are purely in local policy and features.
 :::
 
 ## Version Numbering
@@ -78,7 +78,7 @@ Bitcoin Knots takes a more conservative approach than Bitcoin Core regarding blo
 4. **Feature Inclusion**: Includes useful features that Core hasn't prioritized or has removed
 
 :::tip The OP_RETURN Controversy
-The philosophical differences between Knots and Core came to a head in 2025 with Bitcoin Core v30's controversial removal of OP_RETURN limits. Nick Szabo, Jimmy Song, and Luke Dashjr were among the prominent voices opposing the change. The fight has since moved to the [BIP-110/RDTS soft fork](/guides/bip-110), which shipped as an opt-in feature in Knots 29.3. [Read the full story →](/guides/op-return-controversy)
+The philosophical differences between Knots and Core came to a head in 2025 with Bitcoin Core v30's controversial removal of OP_RETURN limits. Nick Szabo, Jimmy Song, and Luke Dashjr were among the prominent voices opposing the change. The fight has since moved to the [BIP-110/RDTS soft fork](/guides/bip-110), which ships in Knots 29.3. [Read the full story →](/guides/op-return-controversy)
 :::
 
 ## Notable Features
@@ -88,7 +88,7 @@ The philosophical differences between Knots and Core came to a head in 2025 with
 | `-rejectparasites` | Filter CAT21 spam transactions (on by default) |
 | `-datacarriersize` | Configurable OP_RETURN limit (83 bytes default) |
 | `-corepolicy` | Single flag to use Bitcoin Core defaults instead |
-| `-consensusrules` | Opt-in enforcement of the [BIP-110/RDTS soft fork](/guides/bip-110) (off by default, new in v29.3) |
+| `-consensusrules` | Confirmation setting for the [BIP-110/RDTS soft fork](/patches/consensus/bip110) (new in v29.3) |
 | Legacy Wallet | Maintained support (removed in Core 30) |
 | Embedded Tor | Built-in Tor subprocess management |
 | Dark Mode | GUI dark theme support |

--- a/docs/guides/bip-110.md
+++ b/docs/guides/bip-110.md
@@ -11,7 +11,7 @@ BIP-110, the **Reduced Data Temporary Softfork (RDTS)** — originally floated a
 :::info Current Status (July 2026)
 - **Official designation**: [BIP-110](https://github.com/bitcoin/bips/blob/master/bip-0110.mediawiki) in the bitcoin/bips repository
 - **Author**: Dathon Ohm (pseudonymous)
-- **Shipped in Bitcoin Knots**: v29.3.knots20260508 (May 2026) includes RDTS as an **opt-in** (`consensusrules=rdts`)
+- **Shipped in Bitcoin Knots**: the standard v29.3.knots20260508 build (May 2026) enforces RDTS on its schedule; a non-enforcing build is also published — see [BIP-110 / RDTS Integration](/patches/consensus/bip110)
 - **Signaling**: live since March 2026, but minimal — roughly **0.31% of hashrate** (~5 EH/s of ~940 EH/s) as of late June 2026, almost entirely from Ocean pool
 - **Threshold**: 55% of blocks in a difficulty period (1,109 of 2,016) for early lock-in
 - **Next milestone**: mandatory signaling period at blocks 961,632–963,647 (early August 2026); activation at height 965,664 (~September 1, 2026)
@@ -65,13 +65,13 @@ Block 1,018,080  Auto-expiry (~52,416 blocks, ~1 year later)
 
 ### Bitcoin Knots v29.3 (the mainstream route)
 
-Since May 2026, the primary way to enforce BIP-110 is **Bitcoin Knots itself**: v29.3.knots20260508 ships RDTS as a strictly opt-in feature. Users must explicitly confirm adoption via a GUI prompt, or add to `bitcoin.conf`:
+Since May 2026, the primary way to enforce BIP-110 is **Bitcoin Knots itself**: the standard v29.3.knots20260508 build enforces RDTS on its deployment schedule, and asks each user for explicit confirmation — a GUI prompt at startup, or in `bitcoin.conf`:
 
 ```ini
 consensusrules=rdts
 ```
 
-RDTS is **disabled by default**. A parallel build without any RDTS support (v29.3.knots20260507) is published for users who prefer a client that cannot enforce it at all.
+Note that the setting records confirmation rather than toggling enforcement — in this build, enforcement follows the deployment schedule regardless, and unconfirmed `bitcoind` nodes log hourly warnings. A parallel build without any RDTS enforcement (v29.3.knots20260507) is published for users who prefer a client that cannot enforce it at all. For the full mechanics — the two builds, the confirmation flow, build flags, and how to monitor enforcement — see **[BIP-110 / RDTS Integration](/patches/consensus/bip110)**.
 
 ### The Standalone Activation Client
 
@@ -81,7 +81,7 @@ Before Knots shipped RDTS, the pseudonymous author distributed a standalone acti
 |---------|------|--------|
 | **RC1** | December 10, 2025 | Buggy — severe criticism |
 | **RC2** | January 3, 2026 | Fixes applied |
-| **Knots v29.3.knots20260508** | May 8, 2026 | RDTS shipped opt-in in mainline Knots |
+| **Knots v29.3.knots20260508** | May 8, 2026 | RDTS shipped in mainline Knots (confirmation required) |
 
 ### RC1 Problems
 
@@ -175,13 +175,13 @@ With early lock-in out of reach, attention has shifted to the mandatory signalin
 
 ## Relationship to Bitcoin Knots
 
-BIP-110 is built on **Bitcoin Knots**, not Bitcoin Core — and since v29.3.knots20260508 (May 2026), mainline Knots ships it as an opt-in. This is significant because:
+BIP-110 is built on **Bitcoin Knots**, not Bitcoin Core — and since v29.3.knots20260508 (May 2026), the standard mainline Knots build enforces it. This is significant because:
 
 - Knots already has conservative defaults (83-byte OP_RETURN limit)
 - Knots users are the natural constituency for BIP-110
-- The roughly 23% of reachable nodes running Knots (July 2026) represents the potential base — though only an estimated 2–8% of listening nodes run BIP-110-capable software, and opting in is a further explicit step
+- The roughly 23% of reachable nodes running Knots (July 2026) represents the potential base — though only an estimated 2–8% of listening nodes currently run BIP-110-capable software
 
-However, even many Knots supporters are skeptical of consensus-level restrictions, preferring policy-level solutions. Knots' default configuration does **not** enforce RDTS.
+However, even many Knots supporters are skeptical of consensus-level restrictions, preferring policy-level solutions — which is one reason a non-enforcing build (v29.3.knots20260507) is published alongside the standard one.
 
 ## What Happens Next?
 
@@ -192,9 +192,9 @@ However, even many Knots supporters are skeptical of consensus-level restriction
 - Restrictions last ~1 year (to block 1,018,080), then expire
 
 **The live scenario — flag-day activation without hashrate support:**
-- Opted-in nodes begin enforcing mandatory signaling at block 961,632 (~early August 2026) and the full restrictions at block 965,664 (~September 1, 2026)
-- If miners keep producing non-signaling blocks, opted-in nodes reject them while the rest of the network follows the majority chain — the chain-split scenario Back and Lopp warn about
-- How much economic weight is behind opted-in nodes at that point determines whether this is a non-event or a serious split
+- Enforcing nodes begin requiring mandatory signaling at block 961,632 (~early August 2026) and the full restrictions at block 965,664 (~September 1, 2026)
+- If miners keep producing non-signaling blocks, enforcing nodes reject them while the rest of the network follows the majority chain — the chain-split scenario Back and Lopp warn about
+- How much economic weight is behind enforcing nodes at that point determines whether this is a non-event or a serious split
 
 **If it expires or fizzles**:
 - No lasting consensus change occurs
@@ -218,7 +218,7 @@ However, even many Knots supporters are skeptical of consensus-level restriction
 
 - [BIP-110 text (bitcoin/bips)](https://github.com/bitcoin/bips/blob/master/bip-0110.mediawiki)
 - [BIP-110 Official Site](https://bip110.org/)
-- [Bitcoin Knots v29.3.knots20260508 release notes](https://github.com/bitcoinknots/bitcoin/releases/tag/v29.3.knots20260508) — RDTS opt-in
+- [Bitcoin Knots v29.3.knots20260508 release notes](https://github.com/bitcoinknots/bitcoin/releases/tag/v29.3.knots20260508) — the release that ships RDTS
 - [A Layman's Guide to BIP-110](https://blog.lopp.net/a-laymans-guide-to-bip-110/) — Jameson Lopp
 - [BIP-110 GitHub Repository](https://github.com/dathonohm/bitcoin)
 - [BIP-110 RC2 Release Notes](https://github.com/dathonohm/bitcoin/releases/tag/v29.2.knots20251110%2Bbip110-v0.1rc2)

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -134,18 +134,18 @@ permitbarepubkey=0
 
 ## Consensus Rules (RDTS / BIP-110)
 
-New in v29.3.knots20260508: Bitcoin Knots ships opt-in support for the Rejecting Data Transaction Softfork (RDTS, BIP-110). The rules are **disabled by default** — you must explicitly opt in, either through the GUI confirmation dialog or in `bitcoin.conf`:
+New in v29.3.knots20260508: Bitcoin Knots ships the Reduced Data Temporary Softfork (RDTS, BIP-110). The standard build **enforces RDTS on its deployment schedule** and asks for your explicit confirmation — through the GUI dialog at startup, or in `bitcoin.conf`:
 
 ```ini title="bitcoin.conf"
-# Opt in to enforcing the RDTS (BIP-110) consensus rules
+# Confirm the RDTS (BIP-110) upgrade; bitcoind warns hourly until this is set
 consensusrules=rdts
 ```
 
-:::danger Consensus opt-in
-Enabling `consensusrules=rdts` changes how your node validates blocks — this is a change to **consensus validation**, not just relay policy. If the soft fork does not gain broad support across the network, nodes enforcing RDTS could follow a different chain than the rest of the network (a chain split). Do not opt in unless you understand and accept these implications. A parallel build without RDTS support (v29.3.knots20260507) is also available.
+:::danger Enforcement is a property of the build
+`consensusrules=rdts` records your confirmation — it does not switch enforcement on or off. RDTS is a change to **consensus validation**, not just relay policy: if the soft fork activates without broad support across the network, enforcing nodes could follow a different chain than the rest of the network (a chain split). If you do not want your node to enforce RDTS, run the parallel build without it (v29.3.knots20260507).
 :::
 
-See [BIP-110](/guides/bip-110) for a full explanation of the proposed rules.
+See [BIP-110 / RDTS Integration](/patches/consensus/bip110) for the full mechanics and [BIP-110](/guides/bip-110) for an explanation of the rules.
 
 ## Wallet Options
 

--- a/docs/guides/mining.md
+++ b/docs/guides/mining.md
@@ -134,16 +134,17 @@ The choice is yours — Knots provides the options, you decide the policy.
 
 ## BIP-110/RDTS Signaling
 
-Miners who want to go beyond relay policy can signal for **BIP-110**, the Reduced Data Temporary Softfork (RDTS). Knots v29.3 ships RDTS enforcement as a strictly opt-in feature:
+Miners running the standard Knots v29.3 build (v29.3.knots20260508) should know that **their block templates signal for BIP-110 automatically**: the Reduced Data Temporary Softfork (RDTS) is a BIP9-style deployment, and `getblocktemplate` sets version bit 4 for any deployment in its signaling phase. Confirming the upgrade in your configuration silences the hourly warnings but does not change signaling:
 
 ```ini title="bitcoin.conf"
-# Opt in to enforcing the RDTS consensus rules (Knots v29.3+)
+# Confirm the RDTS upgrade (Knots v29.3+); enforcement and signaling
+# are properties of the build, not of this setting
 consensusrules=rdts
 ```
 
-GUI users are shown a consent prompt instead, and a separate non-RDTS build is published for those who decline. Ocean has been signaling for BIP-110 since around March 2026, though as of mid-2026 overall network signaling remains well below the 55% activation threshold.
+Miners who do **not** want to signal or enforce RDTS should run the parallel non-RDTS build (v29.3.knots20260507). Ocean has been signaling for BIP-110 since around March 2026, though as of mid-2026 overall network signaling remains well below the 55% early lock-in threshold.
 
-See **[BIP-110: The Reduced Data Soft Fork](/guides/bip-110)** for the full rules, activation timeline, and risks before opting in.
+See **[BIP-110 / RDTS Integration](/patches/consensus/bip110)** for the mechanics and **[BIP-110: The Reduced Data Soft Fork](/guides/bip-110)** for the full rules, activation timeline, and risks.
 
 ## Fee Configuration
 

--- a/docs/guides/op-return-controversy.md
+++ b/docs/guides/op-return-controversy.md
@@ -282,7 +282,7 @@ Some developers argued that policy-level changes weren't enough — **consensus-
 - **Mechanism**: UASF (User-Activated Soft Fork) requiring 55% miner support
 - **Duration**: ~1 year, then auto-expires
 - **Effect**: Seven consensus rules restricting data storage methods
-- **Status**: Now an official BIP. Knots v29.3 ships RDTS enforcement as a strictly **opt-in** feature (`consensusrules=rdts` in the config, or a consent prompt in the GUI; a separate non-RDTS build is also published)
+- **Status**: Now an official BIP. The standard Knots v29.3 build enforces RDTS on its deployment schedule, asking users for explicit confirmation (`consensusrules=rdts` in the config, or a consent prompt in the GUI); a separate non-RDTS build is also published
 
 ### Activation Status (as of July 2026)
 

--- a/docs/patches/consensus/bip110.md
+++ b/docs/patches/consensus/bip110.md
@@ -1,0 +1,155 @@
+---
+sidebar_position: 1
+title: BIP-110 / RDTS Integration
+description: How Bitcoin Knots implements the BIP-110 (RDTS) soft fork — builds, confirmation, config, and monitoring
+---
+
+# BIP-110 / RDTS Integration
+
+Since v29.3.knots20260508 (May 2026), Bitcoin Knots ships the **BIP-110** soft fork — called the **Reduced Data Temporary Softfork (RDTS)** throughout the Knots source and release notes. This page covers the operational side: which builds enforce it, how the confirmation mechanism works, the exact configuration entries and build flags, and how to monitor your node's enforcement status.
+
+For what BIP-110 actually restricts, the activation timeline, and the surrounding debate, see [BIP-110: The Reduced Data Soft Fork](/guides/bip-110).
+
+:::danger Understand what you are running
+BIP-110 is a consensus change with minimal miner signaling so far. If it activates on schedule without broad hashrate support, enforcing nodes can end up on a minority chain — see [chain split risk](/guides/bip-110#technical-concerns). Know which build you are running and what it will enforce before the activation window (September 2026).
+:::
+
+## The Two Builds
+
+Bitcoin Knots v29.3 is published in two variants:
+
+| Build | RDTS enforcement | Who it's for |
+|-------|------------------|--------------|
+| [v29.3.knots20260508](https://bitcoinknots.org/files/29.x/29.3.knots20260508/) | **Yes** — enforces the RDTS deployment on its schedule | Users who accept (or want to support) the upgrade |
+| [v29.3.knots20260507](https://bitcoinknots.org/files/29.x/29.3.knots20260507/) | **No** — RDTS rules are never enforced | Users not ready to adopt RDTS |
+
+:::warning Enforcement is a property of the build, not the config
+A common misconception is that `consensusrules=rdts` switches enforcement on and off. It does not. In the standard 20260508 build, **the RDTS deployment schedule is enforced whether or not you set it** — the option records your explicit confirmation and silences warnings. The way to run v29.3 without RDTS enforcement is to run the 20260507 build.
+:::
+
+The release notes take the position that declining the upgrade does not "reject" it: to actually reject an upgrade that gains network adoption, you would need software designed to split away from the upgraded network. Critics dispute the framing in the other direction — that a soft fork without hashrate majority splits *itself* away. Both perspectives are covered in the [main guide](/guides/bip-110).
+
+## The Confirmation Mechanism
+
+The standard build asks every user for explicit confirmation, and behaves differently until it gets it:
+
+### GUI (bitcoin-qt)
+
+On first startup after upgrading, the GUI shows a **"BIP110/RDTS Network Upgrade"** dialog explaining the change:
+
+- **OK** — your consent is written to `settings.json` (`"consensusrules": "rdts"`) so you are not asked again.
+- **Abort** — the GUI exits. It does not run unconfirmed.
+
+### Daemon (bitcoind)
+
+`bitcoind` starts and enforces RDTS even without confirmation, but logs an error **every hour** until you confirm:
+
+```
+This software applies the BIP110/RDTS network upgrade, which fixes critical
+vulnerabilities, but explicit user confirmation has not been configured.
+To confirm this upgrade and dismiss this warning, add to your bitcoin.conf
+file: consensusrules=rdts
+```
+
+### Test networks
+
+Confirmation is not required on test chains (testnet, signet, regtest).
+
+## Configuration Entries
+
+Confirmation can be recorded in any of the usual configuration channels:
+
+```ini title="bitcoin.conf"
+consensusrules=rdts
+```
+
+```bash
+# Or as a command-line argument
+bitcoind -consensusrules=rdts
+```
+
+```json title="settings.json (written automatically when you click OK in the GUI)"
+{
+  "consensusrules": "rdts"
+}
+```
+
+From `bitcoind -help-debug`:
+
+```
+-consensusrules=<rules>
+       Enforce the specified consensus rules (default: none). Must be rdts to
+       use this software.
+```
+
+There is no environment variable for this — Bitcoin Knots does not read consent (or any options) from the environment.
+
+## Build-Time Flag: `RDTS_CONSENT`
+
+For source builds, the consent behavior is fixed at compile time by a required CMake option:
+
+```bash
+cmake -B build -D RDTS_CONSENT=RUNTIME_WARN
+```
+
+| Value | Behavior when unconfirmed |
+|-------|---------------------------|
+| `RUNTIME_WARN` | Enforces RDTS; warns hourly until `consensusrules=rdts` is set. **This is what official release binaries use.** |
+| `RUNTIME_CHECK` | Refuses to start: `bitcoind` exits with "User has not consented to supported protocol rules." (The GUI internally escalates `RUNTIME_WARN` to this, which is why it prompts.) |
+| `IMPLICIT` | Consent is assumed at installation; no prompt, no warning. Intended for packagers whose install process obtains consent. |
+| `UNSUPPORTED_UNSAFE_NO_ENFORCEMENT` | Does not enforce RDTS, warns hourly, and drops the `NODE_REDUCED_DATA` service advertisement. The build system explicitly labels this unsupported ("Use at your own risk"). |
+
+Configuring without setting `RDTS_CONSENT` fails with an error listing the options. There is also a debug-only runtime override, `-rdts_consent_flag=<n>`, for testing the consent modes — it is hidden behind `-help-debug` and not meant for production use.
+
+## Deployment Parameters (Mainnet)
+
+Source-verified from `src/kernel/chainparams.cpp`:
+
+| Parameter | Value |
+|-----------|-------|
+| Deployment name | `reduced_data` |
+| Signal bit | 4 |
+| Signaling start | December 1, 2025 (timestamp 1764547200) |
+| Early lock-in threshold | 1,109 of 2,016 blocks (55%) |
+| Maximum activation height | 965,664 (~September 1, 2026) |
+| Active duration | 52,416 blocks (~1 year) |
+| Expiry height | 1,018,080 |
+
+## Monitoring Your Node
+
+### Deployment status
+
+```bash
+bitcoin-cli getdeploymentinfo
+```
+
+Look for the `reduced_data` deployment in the result. During signaling it reports BIP9-style status (`started`, `locked_in`, `active`) and per-period statistics, including how many blocks in the current window are signaling bit 4.
+
+### Service advertisement
+
+Nodes enforcing RDTS advertise a dedicated service bit, `NODE_REDUCED_DATA` (bit 27):
+
+```bash
+# Your own node's services
+bitcoin-cli getnetworkinfo | jq '.localservicesnames'
+
+# Which of your peers advertise RDTS enforcement
+bitcoin-cli getpeerinfo | jq '.[] | {addr, rdts: (.servicesnames | contains(["REDUCED_DATA"]))}'
+```
+
+This is also how network crawlers count BIP-110-capable nodes — see the [node statistics resources](/reference/resources) for a live `NODE_REDUCED_DATA` query.
+
+### Startup logs
+
+`debug.log` records the consent state at startup, e.g. `User already consented to 'rdts' consensus rules (in config)`, and carries the hourly warnings described above when unconfirmed.
+
+## For Miners
+
+Block templates produced by an RDTS-enforcing build **signal bit 4 automatically** while the deployment is in its signaling phase — this is standard BIP9 behavior (`ComputeBlockVersion` sets the bit for any deployment in the `started` or `locked_in` state). In other words, a miner running the standard 20260508 build signals for BIP-110 by default; a miner who does not want to signal needs the non-RDTS 20260507 build. Ocean pool has been signaling since March 2026 — see the [mining guide](/guides/mining#bip-110rdts-signaling) and [current signaling levels](/guides/bip-110#current-miner-signaling).
+
+## See Also
+
+- [BIP-110: The Reduced Data Soft Fork](/guides/bip-110) — what it restricts, timeline, and the debate
+- [BIP-110 text](https://github.com/bitcoin/bips/blob/master/bip-0110.mediawiki) — the official specification
+- [v29.3.knots20260508 release notes](https://github.com/bitcoinknots/bitcoin/blob/v29.3.knots20260508/doc/release-notes.md) — the release's own RDTS section
+- [Bitcoin Knots RDTS information page](https://bitcoinknots.org/learn/2026-rdts) — linked from the confirmation prompt itself

--- a/docs/patches/overview.md
+++ b/docs/patches/overview.md
@@ -114,9 +114,9 @@ Enhancements for miners.
 
 ### Consensus
 
-New in v29.3: Bitcoin Knots ships the opt-in **Reduced Data Temporary Softfork (RDTS, BIP-110)**. It requires explicit confirmation — via the GUI startup prompt or by adding `consensusrules=rdts` to `bitcoin.conf`.
+New in v29.3: Bitcoin Knots ships the **Reduced Data Temporary Softfork (RDTS, BIP-110)**. The standard build enforces it on its deployment schedule and asks for explicit confirmation — via the GUI startup prompt or `consensusrules=rdts` in `bitcoin.conf`; a parallel build without RDTS enforcement (v29.3.knots20260507) is also published.
 
-[Learn more about BIP-110 →](/guides/bip-110)
+[BIP-110 / RDTS Integration →](/patches/consensus/bip110) · [The BIP-110 story →](/guides/bip-110)
 
 ### Restored Features
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -16,7 +16,7 @@ Based on Bitcoin Core 29.3.
 
 ### Highlights
 
-- **Opt-in BIP-110/RDTS support**: This build can enforce the Reduced Data Temporary Softfork, but only with explicit confirmation — via a GUI prompt at startup or `consensusrules=rdts` in `bitcoin.conf`. A build without RDTS support (29.3.knots20260507) is also available.
+- **BIP-110/RDTS support**: This build enforces the Reduced Data Temporary Softfork on its deployment schedule and asks for explicit confirmation — via a GUI prompt at startup or `consensusrules=rdts` in `bitcoin.conf` (bitcoind warns hourly until confirmed). A build without RDTS enforcement (29.3.knots20260507) is also available. See [BIP-110 / RDTS Integration](/patches/consensus/bip110).
 - **RAM-aware `dbcache` default**: When `-dbcache` is not set explicitly, Knots now auto-selects a value between 100 MiB and 2 GiB based on system memory (#34641)
 - **`sweepprivkeys` extended**: now also finds segwit (p2wpkh) and taproot (p2tr) UTXOs, in addition to p2pk and p2pkh (knots#296)
 - **"Sweep private key" GUI dialog** added to the File menu (knots#297)
@@ -28,7 +28,7 @@ Based on Bitcoin Core 29.3.
 ### Changes
 
 #### Consensus
-- knots#238: Reduced Data Temporary Softfork (RDTS), implemented as a modified BIP9 temporary deployment (opt-in)
+- knots#238: Reduced Data Temporary Softfork (RDTS), implemented as a modified BIP9 temporary deployment (confirmation required; non-RDTS build published in parallel)
 
 #### Policy
 - knots#272: Penalize effective fee for sub-dust outputs

--- a/docs/reference/configuration-options.md
+++ b/docs/reference/configuration-options.md
@@ -80,9 +80,9 @@ These options are unique to Bitcoin Knots or have different defaults than Bitcoi
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `-consensusrules=<rules>` | string | none | Enforce the specified consensus rules. Set to `rdts` to opt in to the BIP-110/RDTS softfork |
+| `-consensusrules=<rules>` | string | none | Records confirmation of the specified consensus rules. Set to `rdts` to confirm the BIP-110/RDTS softfork (help text: "Must be rdts to use this software") |
 
-RDTS enforcement is **opt-in**: v29.3.knots20260508 asks for explicit confirmation at GUI startup, or you can set `consensusrules=rdts` in `bitcoin.conf`. Without it, the node validates with the same consensus rules as Bitcoin Core.
+Note: in the standard v29.3.knots20260508 build, this option records your **confirmation** of RDTS — enforcement follows the deployment schedule regardless. The GUI prompts at startup (and exits if declined); `bitcoind` runs and enforces but warns hourly until confirmed. A build without RDTS enforcement (29.3.knots20260507) is published separately. See [BIP-110 / RDTS Integration](/patches/consensus/bip110).
 
 ### Core Policy Mode
 

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -10,11 +10,11 @@ description: Frequently asked questions about Bitcoin Knots
 
 ### What is Bitcoin Knots?
 
-Bitcoin Knots is an enhanced derivative of Bitcoin Core, maintained by [Luke Dashjr](https://github.com/luke-jr) since 2011. It includes additional features, policy options, and improvements not available in Bitcoin Core while maintaining identical consensus rules by default (v29.3 adds one explicitly opt-in exception — see the [BIP-110/RDTS section](#bip-110--rdts) below).
+Bitcoin Knots is an enhanced derivative of Bitcoin Core, maintained by [Luke Dashjr](https://github.com/luke-jr) since 2011. It includes additional features, policy options, and improvements not available in Bitcoin Core while maintaining identical consensus rules (with one v29.3 exception on a scheduled activation — see the [BIP-110/RDTS section](#bip-110--rdts) below).
 
 ### Is Bitcoin Knots safe to use?
 
-Yes. By default, Bitcoin Knots follows identical consensus rules to Bitcoin Core, ensuring full network compatibility. The differences are in local policy (what your node relays) and features (GUI, wallet, RPC). Your node will validate the blockchain exactly the same as Core — unless you explicitly opt in to the RDTS softfork in v29.3+ (it is off by default and requires confirmation).
+Yes. By default, Bitcoin Knots follows identical consensus rules to Bitcoin Core, ensuring full network compatibility. The differences are in local policy (what your node relays) and features (GUI, wallet, RPC). Your node currently validates the blockchain exactly the same as Core; the one caveat is the RDTS softfork shipped in v29.3, which the standard build will enforce when it activates (~September 2026) — see the [BIP-110/RDTS section](#bip-110--rdts).
 
 ### Who maintains Bitcoin Knots?
 
@@ -55,7 +55,7 @@ The ~40,000 lines figure is roughly accurate when counting insertions (~36k). Th
 - ~70% is GUI, tests, and docs (zero consensus risk)
 - ~25% is wallet, RPC, policy (affects your node only)
 - Only ~4% (~1,400 lines) is consensus-adjacent
-- **0% changes consensus rules** — Knots validates identically to Core (this analysis covers v29.2; v29.3 later added the opt-in, off-by-default RDTS softfork)
+- **0% changes consensus rules** — Knots validates identically to Core (this analysis covers v29.2; v29.3 later added the RDTS softfork — see below)
 
 **What's in the "consensus-adjacent" code?**
 - `bitcoinconsensus`: **Restored Core code** removed in v28 — already reviewed
@@ -68,7 +68,7 @@ See [Code Analysis](/architecture/code-analysis) for the full breakdown.
 
 | Feature | Bitcoin Core | Bitcoin Knots |
 |---------|--------------|---------------|
-| Consensus Rules | Standard | **Identical by default** (v29.3 adds opt-in RDTS) |
+| Consensus Rules | Standard | **Identical** (v29.3 adds RDTS on a scheduled activation) |
 | Legacy Wallet | Removed (v30) | **Maintained** |
 | OP_RETURN Limit | Removed (v30) | **Configurable** |
 | Inscription Filtering | No | **Yes (default on)** |
@@ -84,7 +84,7 @@ See [Code Analysis](/architecture/code-analysis) for the full breakdown.
 - What features are **available** (GUI, RPC, wallet)
 - What **defaults** are used
 
-By default, your Knots node validates blocks identically to Core. Since v29.3.knots20260508, there is one **explicitly opt-in** exception: the BIP-110/RDTS softfork, which is off by default, requires confirmation to enable, and is also offered as a separate build without it. If RDTS were to activate without broad hashrate support, enforcing nodes could diverge from non-enforcing nodes — see the [BIP-110/RDTS section](#bip-110--rdts) below.
+Today, your Knots node validates blocks identically to Core. Since v29.3.knots20260508 there is one scheduled exception: the standard build includes the BIP-110/RDTS softfork and will enforce it when it activates (~September 2026). The build asks for your explicit confirmation, and a separate build without RDTS (29.3.knots20260507) is offered for users who don't want enforcement. If RDTS activates without broad hashrate support, enforcing nodes could diverge from non-enforcing nodes — see the [BIP-110/RDTS section](#bip-110--rdts) below.
 
 ### Can I run Knots and Core on the same network?
 
@@ -109,7 +109,7 @@ The **Reduced Data Temporary Softfork** (RDTS) is a proposed temporary softfork 
 
 ### Does Knots enforce RDTS?
 
-**Only if you explicitly opt in.** Knots v29.3.knots20260508 ships with RDTS support, but enforcement is **off by default**. To enable it, you must either confirm the GUI prompt shown at startup or add `consensusrules=rdts` to your `bitcoin.conf`. A build of the same version without RDTS support (29.3.knots20260507) is also available for users who don't want it.
+**Depends on which build you run.** The standard v29.3.knots20260508 build enforces the RDTS deployment on its schedule — that is a property of the build, not of your configuration. What the software asks for is explicit *confirmation*: the GUI shows a prompt at startup (and exits if you decline), while `bitcoind` runs and enforces but logs a warning every hour until you add `consensusrules=rdts` to `bitcoin.conf`. If you don't want RDTS enforcement at all, run the parallel build without RDTS support (29.3.knots20260507). Full details: [BIP-110 / RDTS Integration](/patches/consensus/bip110).
 
 ### How would RDTS activate?
 
@@ -119,7 +119,7 @@ As of late June 2026, signaling remains minimal — around **0.31% of hashrate**
 
 ### Is RDTS controversial?
 
-Yes. Critics — including Adam Back and Jameson Lopp — have warned that activating a softfork with minority hashrate support risks a **chain split**: nodes enforcing RDTS could end up following a different chain than the rest of the network. Supporters argue the upgrade fixes long-standing data-abuse vectors. If you enable RDTS, understand that you are opting in to enforcing rules the majority of the network may not enforce.
+Yes. Critics — including Adam Back and Jameson Lopp — have warned that activating a softfork with minority hashrate support risks a **chain split**: nodes enforcing RDTS could end up following a different chain than the rest of the network. Supporters argue the upgrade fixes long-standing data-abuse vectors. If you run an RDTS-enforcing build, understand that after activation it may enforce rules the majority of the network does not.
 
 ---
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -21,6 +21,14 @@ const sidebars: SidebarsConfig = {
         'patches/overview',
         {
           type: 'category',
+          label: 'Consensus',
+          collapsed: true,
+          items: [
+            'patches/consensus/bip110',
+          ],
+        },
+        {
+          type: 'category',
           label: 'Policy Patches',
           collapsed: true,
           items: [

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -188,7 +188,7 @@ function ComparisonSection() {
               <tr>
                 <td>Consensus Rules</td>
                 <td>Standard</td>
-                <td>Identical by default (RDTS opt-in)</td>
+                <td>Identical (RDTS soft fork ships in v29.3)</td>
               </tr>
               <tr>
                 <td>Legacy Wallet</td>


### PR DESCRIPTION
Adds a dedicated operator-focused page, **Patches & Features → Consensus → BIP-110 / RDTS Integration** (`docs/patches/consensus/bip110.md`), covering the technical side of BIP-110 in Knots. All details verified against the v29.3.knots20260508 source:

- **The two builds**: 20260508 (enforcing) vs 20260507 (non-enforcing), and why that distinction — not configuration — determines enforcement
- **Confirmation mechanism**: GUI prompt (OK persists `"consensusrules": "rdts"` to settings.json, Abort exits) vs bitcoind (runs and enforces, warns hourly until confirmed); test chains exempt
- **Config entries**: `consensusrules=rdts` in bitcoin.conf / command line / settings.json — and an explicit note that there is no environment variable
- **Build-time flag**: the required CMake `RDTS_CONSENT` option and its modes (RUNTIME_WARN in official Guix binaries, RUNTIME_CHECK, IMPLICIT, and the unsupported no-enforcement mode), plus the debug-only `-rdts_consent_flag`
- **Deployment parameters**: bit 4, Dec 1 2025 start, 1,109/2,016 threshold, max activation height 965,664, expiry 1,018,080
- **Monitoring**: `getdeploymentinfo` (`reduced_data`), the `NODE_REDUCED_DATA` service bit (bit 27) in getnetworkinfo/getpeerinfo
- **Miners**: templates from an enforcing build signal bit 4 automatically (standard BIP9 `ComputeBlockVersion` behavior)

Source inspection also revealed that the "opt-in, disabled by default" framing shipped in the previous PR was wrong for the standard build: enforcement follows the deployment schedule regardless of configuration — `consensusrules=rdts` records the user's confirmation and silences warnings. This PR corrects that phrasing everywhere it appeared (bip-110 guide, configuration, mining, FAQ, changelog, configuration-options, getting-started pages, architecture banners, patches overview, homepage comparison row) and adds the new Consensus category to the sidebar.

`npm run build` passes with no broken links.