### PR TITLE
Fix homepage comparison table rows

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -197,8 +197,8 @@ function ComparisonSection() {
               </tr>
               <tr>
                 <td>OP_RETURN Policy</td>
-                <td>Fixed</td>
-                <td>Configurable</td>
+                <td>No limit by default (100 kB)</td>
+                <td>83-byte default, deeply configurable</td>
               </tr>
               <tr>
                 <td>Mempool Filtering</td>
@@ -207,13 +207,13 @@ function ComparisonSection() {
               </tr>
               <tr>
                 <td>Dark Mode</td>
-                <td>No</td>
-                <td>Yes</td>
+                <td>Partial</td>
+                <td>Full support</td>
               </tr>
               <tr>
-                <td>Embedded Tor</td>
-                <td>No</td>
-                <td>Yes</td>
+                <td>Tor Integration</td>
+                <td>Manual setup</td>
+                <td>Automatic launch</td>
               </tr>
               <tr>
                 <td>UPnP</td>


### PR DESCRIPTION
Fixes three rows in the homepage Core-vs-Knots comparison table:

- **OP_RETURN Policy**: "Fixed / Configurable" was wrong on the Core side — `-datacarrier`/`-datacarriersize` remain functional options in Core v30 and v31 (verified in both source trees). The accurate contrast is the default: Core defaults to 100 kB (effectively no limit) while Knots defaults to 83 bytes with deeper controls (datacarriercost, datacarrierfullcount, acceptnonstddatacarrier).
- **Dark Mode**: "No / Yes" → "Partial / Full support", consistent with the dark-mode page and FAQ.
- **Embedded Tor → Tor Integration**: "No / Yes" → "Manual setup / Automatic launch", consistent with the corrected Tor docs (Knots auto-launches the system tor; it doesn't bundle it).

Build passes with no broken links.